### PR TITLE
Task 3: test infrastructure — coverage, ProxyClient, command, webview tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Test
-        run: npm test
+      - name: Test with Coverage
+        run: npm run test:coverage
 
       - name: Build
         run: npm run build

--- a/extension/package.json
+++ b/extension/package.json
@@ -651,6 +651,7 @@
     "format": "prettier --write \"**/*.{ts,js,json,md,css,html}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,css,html}\"",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "vscode:prepublish": "npm run build",
     "typecheck": "tsc -p . --noEmit",
     "package:check": "vsce package --allow-missing-repository --baseContentUrl https://example.com/your-org/filemaker-data-api-tools/blob/main --baseImagesUrl https://example.com/your-org/filemaker-data-api-tools/raw/main"
@@ -673,6 +674,7 @@
     "rimraf": "^6.0.1",
     "shx": "^0.4.0",
     "typescript": "^5.8.3",
+    "@vitest/coverage-v8": "^2.1.8",
     "vitest": "^2.1.8"
   }
 }

--- a/extension/test/unit/commands/core.test.ts
+++ b/extension/test/unit/commands/core.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as vscode from 'vscode';
+
+import {
+  parseProfileId,
+  parseLayoutArg,
+  formatError
+} from '../../../src/commands/common';
+import { registerCoreCommands } from '../../../src/commands/index';
+
+describe('parseProfileId', () => {
+  it('returns profileId from valid arg', () => {
+    expect(parseProfileId({ profileId: 'p1' })).toBe('p1');
+  });
+
+  it('returns undefined for null arg', () => {
+    expect(parseProfileId(null)).toBeUndefined();
+  });
+
+  it('returns undefined for non-object arg', () => {
+    expect(parseProfileId('string')).toBeUndefined();
+  });
+
+  it('returns undefined when profileId is not a string', () => {
+    expect(parseProfileId({ profileId: 42 })).toBeUndefined();
+  });
+});
+
+describe('parseLayoutArg', () => {
+  it('extracts layout from arg with layout field', () => {
+    const result = parseLayoutArg({ profileId: 'p1', layout: 'Contacts' });
+    expect(result).toEqual({ profileId: 'p1', layout: 'Contacts' });
+  });
+
+  it('extracts layout from arg with layoutName field', () => {
+    const result = parseLayoutArg({ layoutName: 'Invoices' });
+    expect(result).toEqual({ profileId: undefined, layout: 'Invoices' });
+  });
+
+  it('prefers layout over layoutName', () => {
+    const result = parseLayoutArg({ layout: 'A', layoutName: 'B' });
+    expect(result.layout).toBe('A');
+  });
+
+  it('returns empty object for null arg', () => {
+    expect(parseLayoutArg(null)).toEqual({});
+  });
+});
+
+describe('formatError', () => {
+  it('extracts message from Error', () => {
+    expect(formatError(new Error('boom'))).toContain('boom');
+  });
+
+  it('handles non-Error input', () => {
+    expect(formatError('text')).toBeTruthy();
+  });
+});
+
+describe('registerCoreCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockDeps() {
+    return {
+      context: {
+        subscriptions: [],
+        extensionUri: { fsPath: '/ext' }
+      } as unknown as vscode.ExtensionContext,
+      profileStore: {
+        upsertProfile: vi.fn(),
+        removeProfile: vi.fn(),
+        getProfile: vi.fn(),
+        listProfiles: vi.fn().mockResolvedValue([]),
+        getActiveProfileId: vi.fn().mockReturnValue(undefined),
+        setActiveProfileId: vi.fn()
+      } as never,
+      secretStore: {
+        setPassword: vi.fn(),
+        deletePassword: vi.fn(),
+        setProxyApiKey: vi.fn(),
+        deleteProxyApiKey: vi.fn(),
+        clearProfileSecrets: vi.fn(),
+        getPassword: vi.fn(),
+        getProxyApiKey: vi.fn()
+      } as never,
+      savedQueriesStore: {
+        removeQueriesForProfile: vi.fn()
+      } as never,
+      fmClient: {
+        createSession: vi.fn(),
+        deleteSession: vi.fn(),
+        invalidateProfileCache: vi.fn(),
+        listLayouts: vi.fn().mockResolvedValue([])
+      } as never,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+      } as never,
+      roleGuard: {
+        assertFeature: vi.fn().mockResolvedValue(true),
+        isProfileLocked: vi.fn().mockReturnValue(false)
+      } as never,
+      refreshExplorer: vi.fn(),
+      onProfileDisconnected: vi.fn()
+    };
+  }
+
+  it('registers multiple command disposables', () => {
+    const deps = createMockDeps();
+    const disposables = registerCoreCommands(deps);
+
+    expect(disposables.length).toBeGreaterThan(0);
+    expect(vi.mocked(vscode.commands.registerCommand)).toHaveBeenCalled();
+  });
+
+  it('registers the connect command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.connect');
+  });
+
+  it('registers the disconnect command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.disconnect');
+  });
+
+  it('registers the addConnectionProfile command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.addConnectionProfile');
+  });
+
+  it('registers the removeConnectionProfile command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.removeConnectionProfile');
+  });
+
+  it('registers the editConnectionProfile command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.editConnectionProfile');
+  });
+});

--- a/extension/test/unit/proxyClient.test.ts
+++ b/extension/test/unit/proxyClient.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from 'vitest';
+import nock from 'nock';
+
+import { ProxyClient } from '../../src/services/proxyClient';
+import type { ConnectionProfile } from '../../src/types/fm';
+
+const PROXY_URL = 'https://proxy.example.com';
+const PROXY_PATH = '/api/filemaker';
+
+function createProfile(overrides?: Partial<ConnectionProfile>): ConnectionProfile {
+  return {
+    id: 'test-proxy',
+    name: 'Test Proxy',
+    serverUrl: 'https://fm.example.com',
+    database: 'TestDB',
+    authMode: 'proxy',
+    proxyEndpoint: `${PROXY_URL}${PROXY_PATH}`,
+    ...overrides
+  };
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+}
+
+function createSecretStore() {
+  return {
+    getProxyApiKey: vi.fn().mockResolvedValue('test-api-key'),
+    getPassword: vi.fn().mockResolvedValue(undefined),
+    setPassword: vi.fn(),
+    deletePassword: vi.fn(),
+    setProxyApiKey: vi.fn(),
+    deleteProxyApiKey: vi.fn(),
+    clearProfileSecrets: vi.fn()
+  };
+}
+
+function createClient(secretStore?: ReturnType<typeof createSecretStore>) {
+  return new ProxyClient(secretStore ?? createSecretStore(), createLogger(), 5000);
+}
+
+describe('ProxyClient', () => {
+  describe('createSession', () => {
+    it('returns the session token from the proxy', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'createSession')
+        .reply(200, { ok: true, data: { token: 'abc-session' } });
+
+      const client = createClient();
+      const token = await client.createSession(createProfile());
+
+      expect(token).toBe('abc-session');
+      scope.done();
+    });
+
+    it('throws on proxy error response', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'createSession')
+        .reply(200, { ok: false, error: 'Invalid credentials' });
+
+      const client = createClient();
+      await expect(client.createSession(createProfile())).rejects.toThrow('Invalid credentials');
+      scope.done();
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('completes without error', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'deleteSession')
+        .reply(200, { ok: true, data: {} });
+
+      const client = createClient();
+      await expect(client.deleteSession(createProfile())).resolves.toBeUndefined();
+      scope.done();
+    });
+  });
+
+  describe('listLayouts', () => {
+    it('returns layout names from proxy response', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'listLayouts')
+        .reply(200, {
+          ok: true,
+          data: {
+            layouts: [{ name: 'Contacts' }, { name: 'Invoices' }]
+          }
+        });
+
+      const client = createClient();
+      const layouts = await client.listLayouts(createProfile());
+
+      expect(layouts).toEqual(['Contacts', 'Invoices']);
+      scope.done();
+    });
+  });
+
+  describe('getRecord', () => {
+    it('returns the record from proxy response', async () => {
+      const record = { recordId: '42', fieldData: { Name: 'Alice' } };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'getRecord')
+        .reply(200, { ok: true, data: { record } });
+
+      const client = createClient();
+      const result = await client.getRecord(createProfile(), 'Contacts', '42');
+
+      expect(result.recordId).toBe('42');
+      expect(result.fieldData).toEqual({ Name: 'Alice' });
+      scope.done();
+    });
+
+    it('throws when proxy response has no record', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'getRecord')
+        .reply(200, { ok: true, data: {} });
+
+      const client = createClient();
+      await expect(client.getRecord(createProfile(), 'Contacts', '999')).rejects.toThrow(
+        'Proxy response did not include a record object.'
+      );
+      scope.done();
+    });
+  });
+
+  describe('findRecords', () => {
+    it('returns find results from proxy response', async () => {
+      const findResult = { data: [{ recordId: '1', fieldData: { Name: 'Bob' } }] };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'findRecords')
+        .reply(200, { ok: true, data: { result: findResult } });
+
+      const client = createClient();
+      const result = await client.findRecords(createProfile(), 'Contacts', {
+        query: [{ Name: 'Bob' }]
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].fieldData).toEqual({ Name: 'Bob' });
+      scope.done();
+    });
+  });
+
+  describe('editRecord', () => {
+    it('returns edit result from proxy response', async () => {
+      const editResult = {
+        recordId: '42',
+        modId: '2',
+        messages: [{ code: '0', message: 'OK' }],
+        response: {}
+      };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'editRecord')
+        .reply(200, { ok: true, data: { result: editResult } });
+
+      const client = createClient();
+      const result = await client.editRecord(createProfile(), 'Contacts', '42', { Name: 'Updated' });
+
+      expect(result.recordId).toBe('42');
+      expect(result.modId).toBe('2');
+      scope.done();
+    });
+
+    it('throws when proxy response has no result', async () => {
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'editRecord')
+        .reply(200, { ok: true, data: {} });
+
+      const client = createClient();
+      await expect(
+        client.editRecord(createProfile(), 'Contacts', '42', { Name: 'X' })
+      ).rejects.toThrow('Proxy response did not include an editRecord result payload.');
+      scope.done();
+    });
+  });
+
+  describe('runScript', () => {
+    it('returns script result from proxy response', async () => {
+      const scriptResult = {
+        response: { scriptResult: 'done' },
+        messages: [{ code: '0', message: 'OK' }]
+      };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'runScript')
+        .reply(200, { ok: true, data: { result: scriptResult } });
+
+      const client = createClient();
+      const result = await client.runScript(createProfile(), {
+        layout: 'Contacts',
+        scriptName: 'MyScript'
+      });
+
+      expect(result.response).toEqual({ scriptResult: 'done' });
+      scope.done();
+    });
+  });
+
+  describe('missing proxy endpoint', () => {
+    it('throws when proxy endpoint is missing', async () => {
+      const client = createClient();
+      await expect(
+        client.createSession(createProfile({ proxyEndpoint: '' }))
+      ).rejects.toThrow('Proxy mode requires a proxy endpoint');
+    });
+  });
+
+  describe('createRecord', () => {
+    it('returns create result from proxy response', async () => {
+      const createResult = {
+        recordId: '99',
+        modId: '1',
+        messages: [{ code: '0', message: 'OK' }],
+        response: {}
+      };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'createRecord')
+        .reply(200, { ok: true, data: { result: createResult } });
+
+      const client = createClient();
+      const result = await client.createRecord(createProfile(), 'Contacts', { Name: 'New' });
+
+      expect(result.recordId).toBe('99');
+      scope.done();
+    });
+  });
+
+  describe('deleteRecord', () => {
+    it('returns delete result from proxy response', async () => {
+      const deleteResult = {
+        recordId: '42',
+        messages: [{ code: '0', message: 'OK' }],
+        response: {}
+      };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => body.action === 'deleteRecord')
+        .reply(200, { ok: true, data: { result: deleteResult } });
+
+      const client = createClient();
+      const result = await client.deleteRecord(createProfile(), 'Contacts', '42');
+
+      expect(result.recordId).toBe('42');
+      scope.done();
+    });
+  });
+});

--- a/extension/test/unit/webviews/htmlSnapshots.test.ts
+++ b/extension/test/unit/webviews/htmlSnapshots.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as vscode from 'vscode';
+
+import { buildWebviewCsp, createNonce } from '../../../src/webviews/common/csp';
+import { SchemaDiffPanel } from '../../../src/webviews/schemaDiff/index';
+import type { SchemaDiffResult } from '../../../src/types/fm';
+
+function setupWebviewPanelMock() {
+  let capturedHtml = '';
+  const webview = {
+    onDidReceiveMessage: vi.fn(),
+    postMessage: vi.fn().mockResolvedValue(true),
+    asWebviewUri: vi.fn((uri: { fsPath: string }) => ({
+      toString: () => `https://cdn${uri.fsPath}`
+    })),
+    cspSource: 'https://cdn.test'
+  };
+
+  Object.defineProperty(webview, 'html', {
+    get: () => capturedHtml,
+    set: (v: string) => { capturedHtml = v; },
+    configurable: true
+  });
+
+  const panel = {
+    webview,
+    reveal: vi.fn(),
+    onDidDispose: vi.fn(),
+    dispose: vi.fn(),
+    onDidChangeViewState: vi.fn()
+  };
+
+  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(
+    panel as unknown as vscode.WebviewPanel
+  );
+
+  return { getHtml: () => capturedHtml };
+}
+
+describe('CSP utilities', () => {
+  it('createNonce returns a 32-character alphanumeric string', () => {
+    const nonce = createNonce();
+    expect(nonce).toHaveLength(32);
+    expect(nonce).toMatch(/^[a-zA-Z0-9]+$/);
+  });
+
+  it('consecutive nonces are unique', () => {
+    const a = createNonce();
+    const b = createNonce();
+    expect(a).not.toBe(b);
+  });
+
+  it('buildWebviewCsp includes nonce and required directives', () => {
+    const nonce = 'testNonce12345678901234567890ab';
+    const mockWebview = { cspSource: 'https://cdn.test' } as unknown as vscode.Webview;
+    const csp = buildWebviewCsp(mockWebview, { nonce });
+
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain(`'nonce-${nonce}'`);
+    expect(csp).toContain('script-src');
+    expect(csp).toContain('style-src');
+    expect(csp).toContain('img-src');
+    expect(csp).toContain('connect-src');
+  });
+
+  it('buildWebviewCsp includes inline style nonce when requested', () => {
+    const nonce = 'testNonce12345678901234567890ab';
+    const mockWebview = { cspSource: 'https://cdn.test' } as unknown as vscode.Webview;
+    const csp = buildWebviewCsp(mockWebview, { nonce, allowInlineStyleWithNonce: true });
+
+    // The style-src should have the nonce
+    const styleSrcMatch = csp.match(/style-src\s+([^;]+)/);
+    expect(styleSrcMatch).toBeTruthy();
+    expect(styleSrcMatch![1]).toContain(`nonce-${nonce}`);
+  });
+});
+
+describe('SchemaDiffPanel HTML output', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the static currentPanel reference
+    (SchemaDiffPanel as unknown as { currentPanel: undefined }).currentPanel = undefined;
+  });
+
+  const sampleDiff: SchemaDiffResult = {
+    profileId: 'p1',
+    layout: 'Contacts',
+    comparedAt: '2026-01-01T00:00:00Z',
+    added: [],
+    removed: [],
+    changed: [],
+    summary: { added: 0, removed: 0, changed: 0 },
+    hasChanges: false
+  };
+
+  it('sets HTML on the webview panel', () => {
+    const { getHtml } = setupWebviewPanelMock();
+    const context = {
+      extensionUri: { fsPath: '/ext' },
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext;
+
+    SchemaDiffPanel.createOrShow(context, sampleDiff);
+    const html = getHtml();
+
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it('includes CSP meta tag with nonce', () => {
+    const { getHtml } = setupWebviewPanelMock();
+    const context = {
+      extensionUri: { fsPath: '/ext' },
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext;
+
+    SchemaDiffPanel.createOrShow(context, sampleDiff);
+    const html = getHtml();
+
+    expect(html).toContain('Content-Security-Policy');
+    expect(html).toMatch(/nonce="[a-zA-Z0-9]+"/);
+  });
+
+  it('does not contain inline event handlers', () => {
+    const { getHtml } = setupWebviewPanelMock();
+    const context = {
+      extensionUri: { fsPath: '/ext' },
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext;
+
+    SchemaDiffPanel.createOrShow(context, sampleDiff);
+    const html = getHtml();
+
+    expect(html).not.toMatch(/\sonclick=/i);
+    expect(html).not.toMatch(/\sonload=/i);
+    expect(html).not.toMatch(/\sonerror=/i);
+  });
+
+  it('includes script tag with nonce attribute', () => {
+    const { getHtml } = setupWebviewPanelMock();
+    const context = {
+      extensionUri: { fsPath: '/ext' },
+      subscriptions: []
+    } as unknown as vscode.ExtensionContext;
+
+    SchemaDiffPanel.createOrShow(context, sampleDiff);
+    const html = getHtml();
+
+    expect(html).toMatch(/<script\s+nonce="[a-zA-Z0-9]+"/);
+  });
+});

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
     environment: 'node',
     include: ['test/**/*.test.ts'],
     globals: true,
-    setupFiles: ['test/setup.ts']
+    setupFiles: ['test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts', 'src/webviews/*/ui/**']
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "npm run dev --workspaces --if-present --parallel",
     "dev:extension": "npm run dev -w extension",
     "test": "npm run test --workspaces --if-present",
+    "test:coverage": "npm run test:coverage --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",


### PR DESCRIPTION
## Summary
- Configure `@vitest/coverage-v8` with lcov reporting in vitest.config.ts
- Add `test:coverage` script and update CI to use it
- Add ProxyClient unit tests (13 tests covering all 10 public methods)
- Add command handler tests (16 tests for registration, common utils parsing)
- Add webview HTML snapshot tests (8 tests for CSP nonce, directives, DOM structure)

## Results
- 145 tests pass across 45 test files
- Lint: zero warnings
- Typecheck: zero errors

## Test plan
- [ ] CI build-test passes with coverage
- [ ] New test files execute without errors
- [ ] Coverage report generates in `./coverage/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)