### PR TITLE
Task 5: Create Record and Delete Record end-to-end

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -49,6 +49,8 @@
     "onCommand:filemakerDataApiTools.openGeneratedTypesFolder",
     "onCommand:filemakerDataApiTools.openRecordEditor",
     "onCommand:filemakerDataApiTools.editRecordById",
+    "onCommand:filemakerDataApiTools.createRecord",
+    "onCommand:filemakerDataApiTools.deleteRecord",
     "onCommand:filemakerDataApiTools.batchExportFind",
     "onCommand:filemakerDataApiTools.batchUpdateFromFile",
     "onCommand:filemakerDataApiTools.showJobs",
@@ -213,6 +215,14 @@
         "title": "FileMaker: Edit Record by ID"
       },
       {
+        "command": "filemakerDataApiTools.createRecord",
+        "title": "FileMaker: Create Record"
+      },
+      {
+        "command": "filemakerDataApiTools.deleteRecord",
+        "title": "FileMaker: Delete Record"
+      },
+      {
         "command": "filemakerDataApiTools.batchExportFind",
         "title": "FileMaker: Batch Export (Find)"
       },
@@ -374,6 +384,11 @@
           "command": "filemakerDataApiTools.openRecordEditor",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
           "group": "inline@4"
+        },
+        {
+          "command": "filemakerDataApiTools.createRecord",
+          "when": "view == filemakerExplorer && viewItem == fmLayout",
+          "group": "inline@5"
         },
         {
           "command": "filemakerDataApiTools.editRecordById",

--- a/extension/src/commands/recordEdit.ts
+++ b/extension/src/commands/recordEdit.ts
@@ -7,7 +7,7 @@ import type { ProfileStore } from '../services/profileStore';
 import type { SchemaService } from '../services/schemaService';
 import type { SettingsService } from '../services/settingsService';
 import { validateRecordId } from '../utils/jsonValidate';
-import { parseLayoutArg, pickProfile, promptForLayout } from './common';
+import { parseLayoutArg, pickProfile, promptForLayout, showCommandError } from './common';
 import { RecordEditorPanel } from '../webviews/recordEditor';
 
 interface RegisterRecordEditCommandsDeps {
@@ -124,6 +124,117 @@ export function registerRecordEditCommands(deps: RegisterRecordEditCommandsDeps)
         layout,
         recordId: recordId.trim()
       });
+    }),
+
+    vscode.commands.registerCommand('filemakerDataApiTools.createRecord', async (arg: unknown) => {
+      if (!settingsService.isRecordEditEnabled()) {
+        vscode.window.showInformationMessage('Record editing is disabled by settings.');
+        return;
+      }
+      if (!(await roleGuard.assertFeature('recordEdit', 'Create Record'))) {
+        return;
+      }
+
+      const contextArg = parseLayoutArg(arg);
+      let profileId = contextArg.profileId;
+      let layout = contextArg.layout;
+
+      if (!profileId) {
+        const profile = await pickProfile(profileStore, true);
+        if (!profile) {
+          return;
+        }
+        profileId = profile.id;
+      }
+
+      if (!layout) {
+        const profile = await profileStore.getProfile(profileId);
+        if (!profile) {
+          vscode.window.showErrorMessage('Selected profile not found.');
+          return;
+        }
+        layout = await promptForLayout(profile, fmClient);
+      }
+
+      if (!layout) {
+        return;
+      }
+
+      RecordEditorPanel.createOrShow(context, profileStore, fmClient, schemaService, logger, {
+        profileId,
+        layout,
+        mode: 'create'
+      });
+    }),
+
+    vscode.commands.registerCommand('filemakerDataApiTools.deleteRecord', async (arg: unknown) => {
+      if (!(await roleGuard.assertFeature('writeOperations', 'Delete Record'))) {
+        return;
+      }
+      if (!vscode.workspace.isTrusted) {
+        vscode.window.showWarningMessage('Delete Record is disabled in untrusted workspaces.');
+        return;
+      }
+
+      const contextArg = parseLayoutArg(arg);
+      let profileId = contextArg.profileId;
+      let layout = contextArg.layout;
+
+      if (!profileId) {
+        const profile = await pickProfile(profileStore, true);
+        if (!profile) {
+          return;
+        }
+        profileId = profile.id;
+      }
+
+      const profile = await profileStore.getProfile(profileId);
+      if (!profile) {
+        vscode.window.showErrorMessage('Selected profile not found.');
+        return;
+      }
+
+      if (!layout) {
+        layout = await promptForLayout(profile, fmClient);
+      }
+
+      if (!layout) {
+        return;
+      }
+
+      const recordId = await vscode.window.showInputBox({
+        title: 'Delete Record',
+        prompt: 'Enter the record ID to delete',
+        ignoreFocusOut: true,
+        validateInput: (value) => validateRecordId(value).error
+      });
+
+      if (!recordId) {
+        return;
+      }
+
+      const confirmation = await vscode.window.showWarningMessage(
+        `Delete record ${recordId.trim()} from layout "${layout}"? This cannot be undone.`,
+        { modal: true },
+        'Delete'
+      );
+
+      if (confirmation !== 'Delete') {
+        return;
+      }
+
+      try {
+        const result = await fmClient.deleteRecord(profile, layout, recordId.trim());
+        vscode.window.showInformationMessage(
+          `Record ${result.recordId} deleted from "${layout}".`
+        );
+      } catch (error) {
+        await showCommandError(error, {
+          fallbackMessage: 'Failed to delete record.',
+          logger,
+          logMessage: 'Delete record command failed.'
+        });
+      }
     })
   ];
 }

--- a/extension/src/webviews/recordEditor/index.ts
+++ b/extension/src/webviews/recordEditor/index.ts
@@ -13,6 +13,7 @@ interface RecordEditorOpenOptions {
   profileId?: string;
   layout?: string;
   recordId?: string;
+  mode?: 'edit' | 'create';
 }
 
 interface LoadRecordPayload {
@@ -33,6 +34,7 @@ type IncomingMessage =
   | { type: 'validateDraft'; payload: DraftPayload }
   | { type: 'previewPatch'; payload: DraftPayload }
   | { type: 'saveRecord'; payload: DraftPayload }
+  | { type: 'createRecord'; payload: { profileId: string; layout: string; fieldData: Record<string, unknown> } }
   | { type: 'exportRecord' };
 
 export class RecordEditorPanel {
@@ -81,9 +83,14 @@ export class RecordEditorPanel {
       return;
     }
 
+    const isCreateMode = defaults?.mode === 'create';
+    const panelTitle = isCreateMode && defaults?.layout
+      ? `Create Record — ${defaults.layout}`
+      : 'FileMaker Record Editor';
+
     const panel = vscode.window.createWebviewPanel(
       'filemakerRecordEditor',
-      'FileMaker Record Editor',
+      panelTitle,
       column,
       {
         enableScripts: true,
@@ -130,6 +137,9 @@ export class RecordEditorPanel {
         break;
       case 'saveRecord':
         await this.saveRecord(incoming.payload);
+        break;
+      case 'createRecord':
+        await this.handleCreateRecord(incoming.payload);
         break;
       case 'exportRecord':
         await this.exportCurrentRecord();
@@ -296,6 +306,56 @@ export class RecordEditorPanel {
     }
   }
 
+  private async handleCreateRecord(payload: {
+    profileId: string;
+    layout: string;
+    fieldData: Record<string, unknown>;
+  }): Promise<void> {
+    if (vscode.workspace.getConfiguration('filemaker').get<boolean>('offline.mode', false)) {
+      await this.postError('Offline mode is enabled; record writes are disabled.');
+      return;
+    }
+
+    const profile = await this.profileStore.getProfile(payload.profileId);
+    if (!profile) {
+      await this.postError('Selected profile was not found.');
+      return;
+    }
+
+    const nonEmptyFields = Object.fromEntries(
+      Object.entries(payload.fieldData).filter(([, v]) => v !== '' && v !== undefined && v !== null)
+    );
+
+    if (Object.keys(nonEmptyFields).length === 0) {
+      await this.postError('At least one field must have a value to create a record.');
+      return;
+    }
+
+    const confirmation = await vscode.window.showWarningMessage(
+      `Create a new record in layout "${payload.layout}" with ${Object.keys(nonEmptyFields).length} field(s)?`,
+      { modal: true },
+      'Create'
+    );
+
+    if (confirmation !== 'Create') {
+      await this.panel.webview.postMessage({ type: 'saveCancelled' });
+      return;
+    }
+
+    try {
+      const result = await this.fmClient.createRecord(profile, payload.layout, nonEmptyFields);
+
+      vscode.window.showInformationMessage(`Record created (ID: ${result.recordId}).`);
+
+      await this.panel.webview.postMessage({
+        type: 'recordCreated',
+        payload: { recordId: result.recordId, modId: result.modId }
+      });
+    } catch (error) {
+      await this.postError(formatError(error));
+    }
+  }
+
   private async exportCurrentRecord(): Promise<void> {
     if (!this.loadedRecord) {
       await this.postError('No record has been loaded.');
@@ -418,7 +478,7 @@ function parseIncomingMessage(raw: unknown): IncomingMessage | undefined {
     return { type };
   }
 
-  if (type === 'loadRecord' || type === 'validateDraft' || type === 'previewPatch' || type === 'saveRecord') {
+  if (type === 'loadRecord' || type === 'validateDraft' || type === 'previewPatch' || type === 'saveRecord' || type === 'createRecord') {
     const payload = parseDraftPayload(value.payload, type === 'loadRecord');
     if (!payload) {
       return undefined;

--- a/extension/test/integration/createRecord.integration.test.ts
+++ b/extension/test/integration/createRecord.integration.test.ts
@@ -1,0 +1,118 @@
+import nock from 'nock';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FMClient } from '../../src/services/fmClient';
+import { SecretStore } from '../../src/services/secretStore';
+import type { ConnectionProfile } from '../../src/types/fm';
+import { InMemorySecretStorage } from '../unit/mocks';
+
+const server = 'https://fm.local';
+const apiBase = '/fmi/data/vLatest/databases/TestDB';
+
+function createProfile(): ConnectionProfile {
+  return {
+    id: 'create-profile',
+    name: 'Create',
+    authMode: 'direct',
+    serverUrl: server,
+    database: 'TestDB',
+    username: 'admin',
+    apiBasePath: '/fmi/data',
+    apiVersionPath: 'vLatest'
+  };
+}
+
+async function createClient() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+
+  const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+  await secretStore.setPassword('create-profile', 'password123');
+
+  return new FMClient(secretStore, logger, 5_000);
+}
+
+describe('createRecord integration (mocked HTTP)', () => {
+  it('creates record successfully and returns recordId', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'create-token-1' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .post(`${apiBase}/layouts/Contacts/records`, {
+        fieldData: { FirstName: 'Ada', LastName: 'Lovelace' }
+      })
+      .reply(200, {
+        response: { recordId: '42', modId: '1' },
+        messages: [{ code: '0', message: 'OK' }]
+      });
+
+    const result = await client.createRecord(profile, 'Contacts', {
+      FirstName: 'Ada',
+      LastName: 'Lovelace'
+    });
+
+    expect(result.recordId).toBe('42');
+    expect(result.modId).toBe('1');
+    expect(result.messages.at(0)?.code).toBe('0');
+  });
+
+  it('retries on 401 with re-authentication', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    // First session
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'expired-token' }, messages: [{ code: '0', message: 'OK' }] });
+
+    // First create attempt returns 401
+    nock(server)
+      .post(`${apiBase}/layouts/Contacts/records`)
+      .reply(401, {
+        messages: [{ code: '952', message: 'Invalid FileMaker Data API token' }]
+      });
+
+    // Re-auth
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'fresh-token' }, messages: [{ code: '0', message: 'OK' }] });
+
+    // Retry succeeds
+    nock(server)
+      .post(`${apiBase}/layouts/Contacts/records`)
+      .reply(200, {
+        response: { recordId: '99', modId: '1' },
+        messages: [{ code: '0', message: 'OK' }]
+      });
+
+    const result = await client.createRecord(profile, 'Contacts', { Name: 'Test' });
+    expect(result.recordId).toBe('99');
+  });
+
+  it('throws on server error', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'token-3' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .post(`${apiBase}/layouts/Contacts/records`)
+      .reply(500, {
+        messages: [{ code: '500', message: 'Record creation failed' }]
+      });
+
+    await expect(
+      client.createRecord(profile, 'Contacts', { Name: 'Fail' })
+    ).rejects.toThrow();
+  });
+});

--- a/extension/test/integration/deleteRecord.integration.test.ts
+++ b/extension/test/integration/deleteRecord.integration.test.ts
@@ -1,0 +1,108 @@
+import nock from 'nock';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FMClient } from '../../src/services/fmClient';
+import { SecretStore } from '../../src/services/secretStore';
+import type { ConnectionProfile } from '../../src/types/fm';
+import { InMemorySecretStorage } from '../unit/mocks';
+
+const server = 'https://fm.local';
+const apiBase = '/fmi/data/vLatest/databases/TestDB';
+
+function createProfile(): ConnectionProfile {
+  return {
+    id: 'delete-profile',
+    name: 'Delete',
+    authMode: 'direct',
+    serverUrl: server,
+    database: 'TestDB',
+    username: 'admin',
+    apiBasePath: '/fmi/data',
+    apiVersionPath: 'vLatest'
+  };
+}
+
+async function createClient() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+
+  const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+  await secretStore.setPassword('delete-profile', 'password123');
+
+  return new FMClient(secretStore, logger, 5_000);
+}
+
+describe('deleteRecord integration (mocked HTTP)', () => {
+  it('deletes record successfully', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'delete-token-1' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .delete(`${apiBase}/layouts/Contacts/records/42`)
+      .reply(200, {
+        response: {},
+        messages: [{ code: '0', message: 'OK' }]
+      });
+
+    const result = await client.deleteRecord(profile, 'Contacts', '42');
+
+    expect(result.recordId).toBe('42');
+    expect(result.messages.at(0)?.code).toBe('0');
+  });
+
+  it('throws on 404 record not found', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'delete-token-2' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .delete(`${apiBase}/layouts/Contacts/records/999`)
+      .reply(404, {
+        messages: [{ code: '101', message: 'Record is missing' }]
+      });
+
+    await expect(
+      client.deleteRecord(profile, 'Contacts', '999')
+    ).rejects.toThrow();
+  });
+
+  it('retries on 401 with re-authentication', async () => {
+    const profile = createProfile();
+    const client = await createClient();
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'expired' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .delete(`${apiBase}/layouts/Contacts/records/42`)
+      .reply(401, {
+        messages: [{ code: '952', message: 'Invalid token' }]
+      });
+
+    nock(server)
+      .post(`${apiBase}/sessions`)
+      .reply(200, { response: { token: 'fresh' }, messages: [{ code: '0', message: 'OK' }] });
+
+    nock(server)
+      .delete(`${apiBase}/layouts/Contacts/records/42`)
+      .reply(200, {
+        response: {},
+        messages: [{ code: '0', message: 'OK' }]
+      });
+
+    const result = await client.deleteRecord(profile, 'Contacts', '42');
+    expect(result.recordId).toBe('42');
+  });
+});


### PR DESCRIPTION
## Summary
- Register `createRecord` and `deleteRecord` commands with activation events
- Explorer context menu for Create Record on layout nodes
- RecordEditor create mode (custom title, createRecord handler, confirmation)
- Delete Record with confirmation dialog, role guard, workspace trust check
- Integration tests for both operations (success, 401 retry, error paths)

## Results
- 191 tests across 52 files, all passing
- Lint: zero warnings, Typecheck: zero errors

## Test plan
- [ ] CI build-test passes
- [ ] createRecord integration tests pass
- [ ] deleteRecord integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)