### PR TITLE
Task 6: version bump to 0.6.0 and changelog

### DIFF
--- a/ai/tasks.md
+++ b/ai/tasks.md
@@ -439,7 +439,7 @@ coverage: {
 
 ## Task 5: Add Create Record and Delete Record end-to-end
 
-**Status:** ready_for_codex
+**Status:** done
 **Phase:** 3A-3E
 **Depends on:** none
 **Files to modify/create:**
@@ -593,7 +593,7 @@ export interface DataApiDeleteRecordResponse {
 
 ## Task 6: Final CI pass and version bump
 
-**Status:** pending
+**Status:** done
 **Phase:** 4A
 **Depends on:** all previous tasks
 **Files to modify:**

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,29 +2,39 @@
 
 ## 0.6.0
 
-- Developer experience improvements:
-  - Removed unused `allowUnsafeInlineStyles` CSP option
-  - Added `dev:extension` script for single-workspace watch mode
-  - Standardized error handling with `showCommandError` alias
-- Testing improvements:
-  - Added offline cache key consistency tests
-  - Added batch operation failure scenario tests
-- Performance and scalability:
-  - Added timeout tracking to diagnostics metrics
-  - Added snapshot retention with configurable `maxPerLayout` pruning
-- Security hardening:
-  - Pinned production dependency versions (axios, zod)
-  - Added `npm audit` step to CI pipeline
-  - Added per-session HMAC token to FM bridge server
-  - Added security model documentation for plugin system
-- Feature additions:
-  - Added `UndoRedoStack` class for Layout Mode canvas operations
-  - Added anonymous telemetry opt-in setting
-  - Added multi-profile batch operation types
-  - Added profile export/import commands
-- Distribution and ecosystem:
-  - Added VS Code Marketplace publishing workflow to CI
-  - Updated changelog
+- Webview rendering stability:
+  - Added loading skeleton states to all webviews (no more empty form flash)
+  - Replaced full DOM rebuilds with targeted element updates in recordEditor, queryBuilder, recordViewer, scriptRunner
+  - Added 200ms debounce to recordEditor field input handlers
+  - Fixed layout thrashing in queryBuilder virtual table scroll handler (requestAnimationFrame)
+  - Lowered virtualization threshold from 250 to 50 rows
+  - Added fade-in transitions for schema diff sections
+- Responsive CSS improvements:
+  - Fluid max-width, clamp-based font sizing, fluid padding across all webviews
+  - Removed fixed min-width on tables (horizontal scroll wrapper instead)
+  - Added ARIA attributes for accessibility (aria-live, role=status)
+- Test coverage expansion:
+  - Added coverage reporting with @vitest/coverage-v8 and lcov output
+  - Added ProxyClient unit tests (13 tests covering all public methods)
+  - Added command handler tests (registration, common utils parsing)
+  - Added webview HTML snapshot tests (CSP nonce, directives, DOM structure)
+  - Added fmExplorer tree view tests (root nodes, profile children, refresh)
+  - Added utility tests for errorUx, hash, jsonlWriter, csp
+  - Added integration tests for createRecord and deleteRecord
+  - Total: 191 tests across 52 test files
+- Added Create Record support:
+  - createRecord method in FMClient and ProxyClient
+  - RecordEditor create mode (custom title, confirmation, success message with recordId)
+  - FileMaker: Create Record command with layout picker
+  - Explorer context menu on layout nodes
+- Added Delete Record support:
+  - deleteRecord method in FMClient and ProxyClient
+  - FileMaker: Delete Record command with confirmation dialog
+  - Deletion blocked for viewer role and untrusted workspaces
+- Security:
+  - Bumped axios 1.13.6 to 1.15.0 (SSRF and header injection fixes)
+  - Bumped next 15.5.14 to 15.5.15 (DoS fix)
+  - Added npm audit step to CI pipeline
 
 ## 0.5.1
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "filemaker-data-api-tools",
   "displayName": "FileMaker Data API Tools",
   "description": "VS Code tools for working with the FileMaker Data API (fmrest).",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "publisher": "your-org",
   "license": "MIT",
   "repository": {

--- a/state/controller.md
+++ b/state/controller.md
@@ -1,9 +1,9 @@
 # Controller State
 
-current_state: ready_for_codex
+current_state: ready_for_review
 target_version: 0.6.0
 plan_file: /ai/plan.md
 tasks_file: /ai/tasks.md
 acceptance_file: /ai/acceptance.md
 last_updated: 2026-04-12
-current_task: 5
+current_task: 6

--- a/state/current_task.md
+++ b/state/current_task.md
@@ -1,24 +1,15 @@
 # Current Task
 
-task_id: 5
-title: Add Create Record and Delete Record end-to-end
-status: ready_for_codex
-phase: 3A-3E
-depends_on: none
+task_id: 6
+title: Final CI pass and version bump
+status: done
+phase: 4A
+depends_on: all previous tasks
 
-## Files to modify/create
+## Result
 
-- `extension/src/types/fm.ts`
-- `extension/src/types/dataApi.ts`
-- `extension/src/services/fmClient.ts`
-- `extension/src/services/proxyClient.ts`
-- `extension/test/integration/createRecord.integration.test.ts` (new)
-- `extension/test/integration/deleteRecord.integration.test.ts` (new)
-- `extension/package.json`
-- `extension/src/commands/index.ts`
-- `extension/src/webviews/recordEditor/index.ts`
-- `extension/src/views/fmExplorer.ts`
-
-## Next action
-
-Codex implements Task 5 per instructions in ai/tasks.md.
+- Version bumped to 0.6.0 in extension/package.json
+- CHANGELOG.md updated with complete v0.6.0 release notes
+- All 191 tests pass across 52 files
+- Lint: zero warnings
+- Typecheck: zero errors


### PR DESCRIPTION
## Summary
- Bump version 0.5.1 → 0.6.0 in extension/package.json
- Complete v0.6.0 changelog covering all 6 tasks
- All tasks in v0.6.0 batch are done

## v0.6.0 Release Summary
- Webview rendering stability (loading skeletons, targeted DOM updates, debouncing, rAF scroll)
- Responsive CSS (fluid widths, clamp fonts, ARIA accessibility)
- Test coverage: 108 → 191 tests across 42 → 52 files
- Create Record + Delete Record (types, client, proxy, commands, UI, integration tests)
- Security: axios 1.15.0, next 15.5.15

## Test plan
- [ ] CI build-test passes
- [ ] All 191 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)