### PR TITLE
v0.8.0: Portal Support

### DIFF
--- a/ai/plan.md
+++ b/ai/plan.md
@@ -1,47 +1,13 @@
-# Plan — v0.7.0: Value Lists & Container Fields
+# Plan — v0.8.0: Portal & Related Records
 
 ## Overview
 
-Add value list support and container field handling to the extension. Value lists are a core FileMaker concept — dropdown/radio/checkbox choices tied to fields. Container fields hold binary data (images, PDFs, files). Both are already returned by the Data API metadata endpoint but not yet surfaced in the UI.
+Add portal support utilities for structured portal data extraction, metadata parsing, and request parameter building.
 
-## Phase 1: Value List Support
+## Delivered
 
-### 1A: Types and extraction
-
-Add `ValueListItem` type. Add utility to extract value lists from layout metadata response. The FileMaker Data API returns value lists under `response.valueLists` as an array of `{ name, values: [{ value, displayValue }] }`.
-
-### 1B: Value list display in schema/explorer
-
-Show value lists under layout nodes in the explorer tree. Display value list items in the metadata viewer.
-
-### 1C: Value list dropdowns in Record Editor
-
-When a field has an associated value list, render a `<select>` dropdown instead of a plain `<textarea>` in the Record Editor. Fall back to textarea if no value list is associated.
-
-### 1D: Value list integration in Query Builder
-
-Add value list dropdown for field values in the Query Builder find criteria section when the selected layout has value lists.
-
-## Phase 2: Container Fields
-
-### 2A: Container field detection and URL resolution
-
-Container fields in the Data API return a URL string pointing to the binary content. Add a utility to detect container field types from metadata and resolve the full download URL.
-
-### 2B: Container field display in Record Viewer
-
-When a field is a container type, display it as an image preview (for image types) or a download link (for other types) instead of showing the raw URL string.
-
-### 2C: Container field handling in Record Editor
-
-In create/edit mode, container fields should show as read-only with a note that container uploads require the Data API container upload endpoint. Mark them as non-editable in the field editor.
-
-## Phase 3: Tests and Validation
-
-### 3A: Tests for value lists and container fields
-
-Unit tests for value list extraction, container URL resolution. Integration tests for metadata with value lists. Snapshot updates for webview HTML.
-
-### 3B: Final CI pass and version bump
-
-Run full validation, bump to 0.7.0, update changelog.
+- `extractPortals()` — extract structured PortalInfo from record portalData
+- `extractPortalMetadata()` — parse portal field metadata from layout info
+- `buildPortalParams()` — build portal-aware request parameters with per-portal limit/offset
+- 12 portal utility tests
+- Version bumped to 0.8.0

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.0
+
+- Portal support:
+  - Added `extractPortals()` utility for structured portal data extraction from records
+  - Added `extractPortalMetadata()` for parsing portal field metadata from layout info
+  - Added `buildPortalParams()` for portal-aware find/get request parameters (limit, offset per portal)
+  - Portal field names extracted and sorted, internal fields (recordId/modId) filtered
+- Tests:
+  - 12 portal utility tests (extraction, metadata, params, edge cases)
+  - Total: 226 tests across 55 test files
+
 ## 0.7.0
 
 - Value list support:

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "filemaker-data-api-tools",
   "displayName": "FileMaker Data API Tools",
   "description": "VS Code tools for working with the FileMaker Data API (fmrest).",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "publisher": "your-org",
   "license": "MIT",
   "repository": {

--- a/extension/src/utils/portalUtils.ts
+++ b/extension/src/utils/portalUtils.ts
@@ -1,0 +1,118 @@
+import type { FileMakerRecord } from '../types/fm';
+
+export interface PortalInfo {
+  name: string;
+  records: Array<Record<string, unknown>>;
+  fieldNames: string[];
+  recordCount: number;
+}
+
+/**
+ * Extract portal data from a FileMaker record into structured portal info objects.
+ * Each key in `portalData` is a portal/table occurrence name.
+ */
+export function extractPortals(record: FileMakerRecord): PortalInfo[] {
+  const portalData = record.portalData;
+
+  if (!portalData || typeof portalData !== 'object') {
+    return [];
+  }
+
+  const portals: PortalInfo[] = [];
+
+  for (const [name, rows] of Object.entries(portalData)) {
+    if (!Array.isArray(rows)) {
+      continue;
+    }
+
+    const fieldNames = extractPortalFieldNames(rows);
+
+    portals.push({
+      name,
+      records: rows,
+      fieldNames,
+      recordCount: rows.length
+    });
+  }
+
+  return portals;
+}
+
+/**
+ * Extract the unique field names from portal row data.
+ * Filters out internal fields like `recordId` and `modId`.
+ */
+function extractPortalFieldNames(rows: Array<Record<string, unknown>>): string[] {
+  const fieldSet = new Set<string>();
+
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (key !== 'recordId' && key !== 'modId') {
+        fieldSet.add(key);
+      }
+    }
+  }
+
+  return Array.from(fieldSet).sort();
+}
+
+/**
+ * Extract portal metadata from layout metadata response.
+ * The Data API returns portal metadata under `response.portalMetaData`.
+ */
+export function extractPortalMetadata(
+  metadata: Record<string, unknown>
+): Record<string, Array<{ name: string; type?: string; result?: string }>> {
+  const raw = metadata.portalMetaData;
+
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+
+  const result: Record<string, Array<{ name: string; type?: string; result?: string }>> = {};
+
+  for (const [portalName, fields] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(fields)) {
+      continue;
+    }
+
+    result[portalName] = fields
+      .filter((f): f is Record<string, unknown> => f !== null && typeof f === 'object')
+      .map((f) => ({
+        name: typeof f.name === 'string' ? f.name : String(f.name ?? ''),
+        type: typeof f.type === 'string' ? f.type : undefined,
+        result: typeof f.result === 'string' ? f.result : undefined
+      }));
+  }
+
+  return result;
+}
+
+/**
+ * Build portal request parameters for the Data API find/get endpoints.
+ * Supports limit and offset per portal.
+ */
+export function buildPortalParams(
+  portals: Array<{ name: string; limit?: number; offset?: number }>
+): Record<string, string | number> {
+  const params: Record<string, string | number> = {};
+
+  if (portals.length === 0) {
+    return params;
+  }
+
+  // portal parameter format: portal=["Portal1","Portal2"]
+  params.portal = JSON.stringify(portals.map((p) => p.name));
+
+  for (const portal of portals) {
+    if (portal.limit !== undefined) {
+      params[`_limit.${portal.name}`] = portal.limit;
+    }
+
+    if (portal.offset !== undefined) {
+      params[`_offset.${portal.name}`] = portal.offset;
+    }
+  }
+
+  return params;
+}

--- a/extension/test/unit/portalUtils.test.ts
+++ b/extension/test/unit/portalUtils.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  extractPortals,
+  extractPortalMetadata,
+  buildPortalParams
+} from '../../src/utils/portalUtils';
+import type { FileMakerRecord } from '../../src/types/fm';
+
+describe('extractPortals', () => {
+  it('extracts portal data from a record', () => {
+    const record: FileMakerRecord = {
+      recordId: '1',
+      fieldData: { Name: 'Test' },
+      portalData: {
+        LineItems: [
+          { recordId: '10', 'LineItems::Product': 'Widget', 'LineItems::Qty': 5 },
+          { recordId: '11', 'LineItems::Product': 'Gadget', 'LineItems::Qty': 3 }
+        ]
+      }
+    };
+
+    const portals = extractPortals(record);
+
+    expect(portals).toHaveLength(1);
+    expect(portals[0].name).toBe('LineItems');
+    expect(portals[0].recordCount).toBe(2);
+    expect(portals[0].fieldNames).toContain('LineItems::Product');
+    expect(portals[0].fieldNames).toContain('LineItems::Qty');
+    expect(portals[0].fieldNames).not.toContain('recordId');
+  });
+
+  it('handles multiple portals', () => {
+    const record: FileMakerRecord = {
+      recordId: '1',
+      fieldData: {},
+      portalData: {
+        Items: [{ recordId: '1', 'Items::Name': 'A' }],
+        Notes: [{ recordId: '2', 'Notes::Text': 'Hello' }]
+      }
+    };
+
+    const portals = extractPortals(record);
+    expect(portals).toHaveLength(2);
+  });
+
+  it('returns empty array when no portalData', () => {
+    const record: FileMakerRecord = { recordId: '1', fieldData: {} };
+    expect(extractPortals(record)).toEqual([]);
+  });
+
+  it('returns empty array when portalData is null', () => {
+    const record = { recordId: '1', fieldData: {}, portalData: null } as unknown as FileMakerRecord;
+    expect(extractPortals(record)).toEqual([]);
+  });
+
+  it('handles empty portal arrays', () => {
+    const record: FileMakerRecord = {
+      recordId: '1',
+      fieldData: {},
+      portalData: { Empty: [] }
+    };
+
+    const portals = extractPortals(record);
+    expect(portals).toHaveLength(1);
+    expect(portals[0].recordCount).toBe(0);
+    expect(portals[0].fieldNames).toEqual([]);
+  });
+});
+
+describe('extractPortalMetadata', () => {
+  it('extracts portal field metadata', () => {
+    const metadata = {
+      portalMetaData: {
+        LineItems: [
+          { name: 'LineItems::Product', type: 'normal', result: 'text' },
+          { name: 'LineItems::Qty', type: 'normal', result: 'number' }
+        ]
+      }
+    };
+
+    const result = extractPortalMetadata(metadata);
+    expect(result.LineItems).toHaveLength(2);
+    expect(result.LineItems[0].name).toBe('LineItems::Product');
+    expect(result.LineItems[0].result).toBe('text');
+  });
+
+  it('returns empty object when no portalMetaData', () => {
+    expect(extractPortalMetadata({})).toEqual({});
+  });
+
+  it('handles multiple portals', () => {
+    const metadata = {
+      portalMetaData: {
+        A: [{ name: 'A::X', result: 'text' }],
+        B: [{ name: 'B::Y', result: 'number' }]
+      }
+    };
+
+    const result = extractPortalMetadata(metadata);
+    expect(Object.keys(result)).toEqual(['A', 'B']);
+  });
+});
+
+describe('buildPortalParams', () => {
+  it('builds portal parameter with names', () => {
+    const params = buildPortalParams([{ name: 'LineItems' }, { name: 'Notes' }]);
+
+    expect(params.portal).toBe('["LineItems","Notes"]');
+  });
+
+  it('includes limit and offset per portal', () => {
+    const params = buildPortalParams([
+      { name: 'LineItems', limit: 10, offset: 5 }
+    ]);
+
+    expect(params.portal).toBe('["LineItems"]');
+    expect(params['_limit.LineItems']).toBe(10);
+    expect(params['_offset.LineItems']).toBe(5);
+  });
+
+  it('returns empty object for no portals', () => {
+    expect(buildPortalParams([])).toEqual({});
+  });
+
+  it('omits limit/offset when not specified', () => {
+    const params = buildPortalParams([{ name: 'Items' }]);
+    expect(params.portal).toBeDefined();
+    expect(params['_limit.Items']).toBeUndefined();
+    expect(params['_offset.Items']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `extractPortals()`, `extractPortalMetadata()`, `buildPortalParams()` utilities
- 12 new tests, 226 total across 55 files
- Version bump to 0.8.0

## Test plan
- [ ] CI build-test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)