### PR TITLE
chore: sync enterprise-ai-standards (5.0.0 - 2026-03-25)

### DIFF
--- a/project-manager/enterprise-ai-standards.md
+++ b/project-manager/enterprise-ai-standards.md
@@ -5,7 +5,7 @@ This is the single authoritative standards document for downstream AI-driven del
 Authoritative paths:
 
 - standards: `project-manager/enterprise-ai-standards.md`
-- validator: `tools/validators/enforce-runtime-guardrails.js`
+- validator: `tools/validators/enforce-runtime-guardrails.mjs`
 - config template: `templates/ai.config.json`
 - adoption template: `templates/product-repo-minimal/`
 
@@ -776,7 +776,7 @@ Not allowed:
 
 ## 9. Validator Mapping
 
-| Rule Group | Enforced By `enforce-runtime-guardrails.js` |
+| Rule Group | Enforced By `enforce-runtime-guardrails.mjs` |
 | --- | --- |
 | Layer boundaries | rejects execution-layer environment manifests, repo-external evidence paths, and external state fallbacks |
 | Three-role workflow contract | requires repo workflow files under `ai/` and `state/`, requires a valid `state/controller.md` workflow state, rejects invalid run profiles, and treats workflow files as repo-visible handoff inputs rather than code |


### PR DESCRIPTION
## Standards Sync

This PR updates vendored standards files to match enterprise-ai-standards version **5.0.0 - 2026-03-25**.

### Changed files


### Key changes
- `enforce-runtime-guardrails.mjs`: Converted to ESM (fixes `require is not defined` crash in ESM repos and `no-require-imports` ESLint failures)
- `enforce-runtime-guardrails.mjs.sha256`: New integrity lock — CI now verifies the validator is unmodified before running it
- `AGENTS.md`: Enterprise base updated with `artifacts.json` contract rules (prevents Codex from writing invalid evidence combinations that fail CI)

### Immutability
The validator is now hash-locked. If `enforce-runtime-guardrails.mjs` is modified in this repo, CI will fail with an integrity error before the validator even runs. To update the validator, submit a change to enterprise-ai-standards and run the sync.

### Action required
Review the changes and merge when ready. This is an automated sync — human approval is required.

### Source
enterprise-ai-standards @ `5.0.0 - 2026-03-25`