### PR TITLE
chore: sync enterprise-ai-standards (5.0.0 - 2026-03-25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ Read `ai/bootstrap.md` first — it is the authoritative workflow entry point.
 
 ```
 Claude plans → writes ai/ → sets ready_for_codex
-Codex implements → opens PR → sets ready_for_review  
-CI passes → PR auto-merges (watch-open-prs)
-watch-open-prs → advances state to ready_for_codex (next task)
+Codex implements → opens PR + queues auto-merge → sets ready_for_review
+CI passes → GitHub auto-merges PR instantly (branch protection enforces required checks)
+watch-open-prs → detects merge, advances state to ready_for_codex (next task)
 ```
 
 State flow: `ready_for_codex` → `ready_for_review` → (merge) → `ready_for_codex` | `done`  

--- a/enterprise-ai-standards.md
+++ b/enterprise-ai-standards.md
@@ -817,3 +817,57 @@ Config may relax evidence requirements for specific phases. It must not be used 
 - `night`
 
 Repo-specific Gemini GitHub review behavior may be customized with `.gemini/config.yaml` if desired, but that is optional and does not replace the repo execution contract.
+
+## 11. CI Runner Rules
+
+### CI-1 No macOS runners on pull_request triggers
+
+**macOS GitHub-hosted runners cost approximately 10x ubuntu-latest. They must never be used in pull_request-triggered workflows.**
+
+Any job that requires macOS (native Swift/Tauri/Xcode builds, keychain tests, notarization, native fixture tests) must use one of:
+
+- `workflow_dispatch` (manual trigger)
+- A release-only workflow (e.g. triggered by tag push)
+- A local/self-hosted runner cron
+
+**This is a hard rule enforced by `ai-pipeline.sh repair`.** The `check_macos_pr_jobs` repair check scans all PR-triggered workflow files and removes any job whose `runs-on` references a macOS runner variant (`macos-latest`, `macos-14`, etc.).
+
+Agents (Claude, Codex) must not add `runs-on: macos-*` jobs to any workflow that has a `pull_request:` trigger. If a macOS test is needed for PR validation, flag it for human review — do not add it to CI.
+
+## 12. Security Scanning
+
+### SC-1 Semgrep as the standard static analysis tool
+
+All managed repos use Semgrep for static analysis and security scanning. Semgrep runs via Docker — no per-machine install is required and no macOS runner is needed.
+
+Required image: `semgrep/semgrep:latest`
+
+One-time setup: `semgrep login` on the developer's machine. Credentials are cached in `~/.semgrep/`. CI uses the `SEMGREP_APP_TOKEN` environment variable (never stored in the repo).
+
+### SC-2 Per-repo requirements
+
+Every managed repo must have:
+
+- `.semgrepignore` — excludes `node_modules/`, `.next/`, `dist/`, `build/`, `runs/`, `state/`, `.git/`
+- A `semgrep` step in `scripts/validate.sh` that runs after the existing security step:
+
+```bash
+docker run --rm \
+  -v "$(pwd)":/src \
+  -w /src \
+  -e SEMGREP_APP_TOKEN \
+  semgrep/semgrep \
+  semgrep --config=auto --error .
+```
+
+If Docker is not available in the execution environment, the step must record `NOT RUN` rather than fail the entire validation.
+
+**This is enforced by `ai-pipeline.sh repair`.** The `check_semgrep_config` repair check ensures `.semgrepignore` exists and that `validate.sh` contains the semgrep Docker invocation.
+
+### SC-3 Fleet sweep
+
+`brew-sync/tools/semgrep/scan-all.sh` runs Semgrep across all repos listed in `repos.json`. Use this for full-fleet scans on demand. Results are printed per-repo as PASS/FAIL.
+
+### SC-4 Custom rules
+
+Repo-specific or pipeline-specific Semgrep rules live in `brew-sync/tools/semgrep/rules/`. Rules must be YAML files conforming to the Semgrep rule schema. Agents must not modify rule files without explicit instruction.


### PR DESCRIPTION
## Standards Sync

This PR updates vendored standards files to match enterprise-ai-standards version **5.0.0 - 2026-03-25**.

### Changed files


### Key changes
- `enforce-runtime-guardrails.mjs`: Converted to ESM (fixes `require is not defined` crash in ESM repos and `no-require-imports` ESLint failures)
- `enforce-runtime-guardrails.mjs.sha256`: New integrity lock — CI now verifies the validator is unmodified before running it
- `AGENTS.md`: Enterprise base updated with `artifacts.json` contract rules (prevents Codex from writing invalid evidence combinations that fail CI)

### Immutability
The validator is now hash-locked. If `enforce-runtime-guardrails.mjs` is modified in this repo, CI will fail with an integrity error before the validator even runs. To update the validator, submit a change to enterprise-ai-standards and run the sync.

### Action required
Review the changes and merge when ready. This is an automated sync — human approval is required.

### Source
enterprise-ai-standards @ `5.0.0 - 2026-03-25`