### PR TITLE
chore(deps): postcss override + uuid Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # uuid >=9 has a breaking ESM-first redesign that the @vscode/vsce →
+      # @azure/identity → @azure/msal-node transitive chain (still on uuid@^8
+      # as of msal-node 5.1.4) cannot consume. Re-enable once msal-node
+      # publishes a release that requires uuid >=9.
+      - dependency-name: uuid
+        update-types:
+          - version-update:semver-major

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "format:check": "npm run format:check --workspaces --if-present",
     "package:check": "npm run package:check -w extension",
     "setup": "node ./setup.mjs"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry forcing `postcss: ^8.5.10`, addressing the open Dependabot security advisory.
- Adds `.github/dependabot.yml` to suppress uuid major-version bumps that cannot land because of an upstream constraint.

## Why postcss needs an override
`next@15.5.15` exact-pins `postcss: 8.4.31`, blocking Dependabot from auto-updating. `postcss` 8.4.x → 8.5.x is API-compatible (CSS parser internals, no public API breakage).

## Why uuid is ignored, not overridden
The advisory wants `uuid: ^14.0.0`, but `@vscode/vsce` → `@azure/identity` → `@azure/msal-node@5.1.4` (current latest) still requires `uuid@^8.3.0` and uses the v8 CJS API. uuid v14 is ESM-first with breaking export changes, so an override would break msal-node at runtime. The ignore is scoped narrowly (semver-major only) so a future patch/minor bump can still land — re-enable when upstream msal-node bumps uuid.

## Lockfile note
Local `npm install` was failing in this sandbox (`EBADF`/`ENOTCONN` on tarball fetches), so this PR ships the `package.json` change only — CI's `npm install` reconciles the lockfile against the override. Build verified passing.

## Test plan
- [x] CI `build-test` passes (lint, typecheck, vitest, build, package check)
- [x] CodeQL passes
- [ ] After merge, watch next Dependabot run for uuid: should be suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)