### PR TITLE
Reliability: Graceful fallback in secretStore when VS Code SecretStorage unavailable (#51)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -671,6 +671,16 @@
           "type": "boolean",
           "default": false,
           "description": "Enable anonymous usage telemetry to help improve the extension. No personal data or FileMaker credentials are collected."
+        },
+        "filemaker.secrets.fallback": {
+          "type": "string",
+          "enum": [
+            "vscode-only",
+            "workspace-state",
+            "disabled"
+          ],
+          "default": "vscode-only",
+          "description": "Behavior when VS Code SecretStorage is unavailable. 'vscode-only' (default) propagates the error. 'workspace-state' encrypts secrets to workspace state for headless / remote-agent setups. 'disabled' skips secret persistence entirely (development only)."
         }
       }
     }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -45,7 +45,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   await roleGuard.applyContexts();
 
   const profileStore = new ProfileStore(context.globalState, context.workspaceState);
-  const secretStore = new SecretStore(context.secrets);
+  const secretFallbackMode = settingsService.getSecretsFallbackMode();
+  const secretStore = new SecretStore(context.secrets, {
+    fallbackMode: secretFallbackMode,
+    workspaceState:
+      secretFallbackMode === 'workspace-state' ? context.workspaceState : undefined,
+    machineId: vscode.env.machineId,
+    logger,
+    onFallbackEngaged: (mode, reason) => {
+      const text =
+        mode === 'workspace-state'
+          ? `FileMaker: SecretStorage unavailable (${reason}); falling back to encrypted workspace state.`
+          : `FileMaker: SecretStorage unavailable (${reason}); secret persistence is disabled.`;
+      void vscode.window.showWarningMessage(text);
+    }
+  });
   const offlineModeService = new OfflineModeService(logger);
   const environmentSetStore = new EnvironmentSetStore(context.workspaceState);
   const savedQueriesStore = new SavedQueriesStore(context.globalState, context.workspaceState, {

--- a/extension/src/services/secretStore.ts
+++ b/extension/src/services/secretStore.ts
@@ -1,50 +1,111 @@
+import * as crypto from 'crypto';
 import type * as vscode from 'vscode';
+
+import type { Logger } from './logger';
 
 const PASSWORD_PREFIX = 'filemakerDataApiTools.profile.password';
 const TOKEN_PREFIX = 'filemakerDataApiTools.profile.sessionToken';
 const PROXY_KEY_PREFIX = 'filemakerDataApiTools.profile.proxyApiKey';
+const FALLBACK_KEY = 'filemakerDataApiTools.fallbackSecrets.v1';
 
 function profileKey(prefix: string, profileId: string): string {
   return `${prefix}.${profileId}`;
 }
 
+export type SecretFallbackMode = 'vscode-only' | 'workspace-state' | 'disabled';
+
+interface FallbackEnvelope {
+  v: 1;
+  saltHex: string;
+  ivHex: string;
+  ciphertextHex: string;
+  tagHex: string;
+}
+
+type FallbackMap = Record<string, FallbackEnvelope>;
+
+type SecretLogger = Pick<Logger, 'warn' | 'info' | 'error'>;
+
+export interface SecretStoreOptions {
+  /**
+   * Fallback strategy when vscode.SecretStorage throws or is unavailable.
+   * - 'vscode-only' (default): rethrow; no fallback (preserves prior behavior)
+   * - 'workspace-state': encrypt and persist to Memento; for headless CI / remote agents
+   * - 'disabled': do not persist any secrets; reads return undefined; writes are no-ops
+   */
+  fallbackMode?: SecretFallbackMode;
+  /** Memento used as the workspace-state fallback. Required when fallbackMode === 'workspace-state'. */
+  workspaceState?: vscode.Memento;
+  /**
+   * Stable identifier mixed into the encryption key. Defaults to empty string.
+   * Pass vscode.env.machineId at the call site so secrets cannot be decrypted on a different machine.
+   */
+  machineId?: string;
+  /** Logger for fallback warnings. */
+  logger?: SecretLogger;
+  /** Called once per instance when the fallback is first engaged. Inject the toast at the call site. */
+  onFallbackEngaged?: (mode: SecretFallbackMode, reason: string) => void;
+}
+
 export class SecretStore {
-  public constructor(private readonly secrets: vscode.SecretStorage) {}
+  private readonly fallbackMode: SecretFallbackMode;
+  private readonly workspaceState?: vscode.Memento;
+  private readonly machineId: string;
+  private readonly logger?: SecretLogger;
+  private readonly onFallbackEngaged: NonNullable<SecretStoreOptions['onFallbackEngaged']>;
+  private fallbackNotified = false;
+
+  public constructor(
+    private readonly secrets: vscode.SecretStorage,
+    options: SecretStoreOptions = {}
+  ) {
+    this.fallbackMode = options.fallbackMode ?? 'vscode-only';
+    this.workspaceState = options.workspaceState;
+    this.machineId = options.machineId ?? '';
+    this.logger = options.logger;
+    this.onFallbackEngaged = options.onFallbackEngaged ?? (() => {});
+
+    if (this.fallbackMode === 'workspace-state' && !this.workspaceState) {
+      throw new Error(
+        "SecretStore: fallbackMode='workspace-state' requires options.workspaceState"
+      );
+    }
+  }
 
   public async setPassword(profileId: string, password: string): Promise<void> {
-    await this.secrets.store(profileKey(PASSWORD_PREFIX, profileId), password);
+    await this.set(profileKey(PASSWORD_PREFIX, profileId), password);
   }
 
   public async getPassword(profileId: string): Promise<string | undefined> {
-    return this.secrets.get(profileKey(PASSWORD_PREFIX, profileId));
+    return this.get(profileKey(PASSWORD_PREFIX, profileId));
   }
 
   public async deletePassword(profileId: string): Promise<void> {
-    await this.secrets.delete(profileKey(PASSWORD_PREFIX, profileId));
+    await this.delete(profileKey(PASSWORD_PREFIX, profileId));
   }
 
   public async setSessionToken(profileId: string, token: string): Promise<void> {
-    await this.secrets.store(profileKey(TOKEN_PREFIX, profileId), token);
+    await this.set(profileKey(TOKEN_PREFIX, profileId), token);
   }
 
   public async getSessionToken(profileId: string): Promise<string | undefined> {
-    return this.secrets.get(profileKey(TOKEN_PREFIX, profileId));
+    return this.get(profileKey(TOKEN_PREFIX, profileId));
   }
 
   public async deleteSessionToken(profileId: string): Promise<void> {
-    await this.secrets.delete(profileKey(TOKEN_PREFIX, profileId));
+    await this.delete(profileKey(TOKEN_PREFIX, profileId));
   }
 
   public async setProxyApiKey(profileId: string, apiKey: string): Promise<void> {
-    await this.secrets.store(profileKey(PROXY_KEY_PREFIX, profileId), apiKey);
+    await this.set(profileKey(PROXY_KEY_PREFIX, profileId), apiKey);
   }
 
   public async getProxyApiKey(profileId: string): Promise<string | undefined> {
-    return this.secrets.get(profileKey(PROXY_KEY_PREFIX, profileId));
+    return this.get(profileKey(PROXY_KEY_PREFIX, profileId));
   }
 
   public async deleteProxyApiKey(profileId: string): Promise<void> {
-    await this.secrets.delete(profileKey(PROXY_KEY_PREFIX, profileId));
+    await this.delete(profileKey(PROXY_KEY_PREFIX, profileId));
   }
 
   public async clearProfileSecrets(profileId: string): Promise<void> {
@@ -53,5 +114,161 @@ export class SecretStore {
       this.deleteSessionToken(profileId),
       this.deleteProxyApiKey(profileId)
     ]);
+  }
+
+  // --- internals ---
+
+  private async set(key: string, value: string): Promise<void> {
+    if (this.fallbackMode === 'disabled') {
+      this.logger?.warn(
+        `[secretStore] fallback=disabled; skipping persist for ${maskKey(key)}`
+      );
+      return;
+    }
+    try {
+      await this.secrets.store(key, value);
+      // Successful primary write supersedes any prior fallback for this key.
+      if (this.workspaceState) {
+        await this.clearFallbackEntry(key).catch(() => {});
+      }
+    } catch (err) {
+      if (this.fallbackMode === 'workspace-state') {
+        this.notifyFallback('SecretStorage.store failed', err);
+        await this.fallbackSet(key, value);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async get(key: string): Promise<string | undefined> {
+    if (this.fallbackMode === 'disabled') {
+      return undefined;
+    }
+    try {
+      const value = await this.secrets.get(key);
+      if (value !== undefined) {
+        return value;
+      }
+      if (this.fallbackMode === 'workspace-state') {
+        return this.fallbackGet(key);
+      }
+      return undefined;
+    } catch (err) {
+      if (this.fallbackMode === 'workspace-state') {
+        this.notifyFallback('SecretStorage.get failed', err);
+        return this.fallbackGet(key);
+      }
+      throw err;
+    }
+  }
+
+  private async delete(key: string): Promise<void> {
+    if (this.fallbackMode === 'disabled') {
+      return;
+    }
+    try {
+      await this.secrets.delete(key);
+    } catch (err) {
+      if (this.fallbackMode !== 'workspace-state') {
+        throw err;
+      }
+      this.notifyFallback('SecretStorage.delete failed', err);
+    } finally {
+      if (this.fallbackMode === 'workspace-state') {
+        await this.clearFallbackEntry(key).catch(() => {});
+      }
+    }
+  }
+
+  private notifyFallback(reason: string, err: unknown): void {
+    this.logger?.warn(
+      `[secretStore] using ${this.fallbackMode} fallback (${reason}): ${describeError(err)}`
+    );
+    if (!this.fallbackNotified) {
+      this.fallbackNotified = true;
+      this.onFallbackEngaged(this.fallbackMode, reason);
+    }
+  }
+
+  private async fallbackSet(key: string, value: string): Promise<void> {
+    if (!this.workspaceState) return;
+    const envelope = this.encrypt(value);
+    const map: FallbackMap = { ...this.readFallbackMap(), [key]: envelope };
+    await this.workspaceState.update(FALLBACK_KEY, map);
+  }
+
+  private fallbackGet(key: string): string | undefined {
+    if (!this.workspaceState) return undefined;
+    const entry = this.readFallbackMap()[key];
+    if (!entry) return undefined;
+    try {
+      return this.decrypt(entry);
+    } catch (err) {
+      this.logger?.error(
+        `[secretStore] fallback decrypt failed for ${maskKey(key)}: ${describeError(err)}`
+      );
+      return undefined;
+    }
+  }
+
+  private async clearFallbackEntry(key: string): Promise<void> {
+    if (!this.workspaceState) return;
+    const map = this.readFallbackMap();
+    if (!(key in map)) return;
+    const next: FallbackMap = { ...map };
+    delete next[key];
+    await this.workspaceState.update(FALLBACK_KEY, next);
+  }
+
+  private readFallbackMap(): FallbackMap {
+    return this.workspaceState?.get<FallbackMap>(FALLBACK_KEY) ?? {};
+  }
+
+  private encrypt(plaintext: string): FallbackEnvelope {
+    const salt = crypto.randomBytes(16);
+    const iv = crypto.randomBytes(12);
+    const key = this.deriveKey(salt);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return {
+      v: 1,
+      saltHex: salt.toString('hex'),
+      ivHex: iv.toString('hex'),
+      ciphertextHex: ct.toString('hex'),
+      tagHex: tag.toString('hex')
+    };
+  }
+
+  private decrypt(envelope: FallbackEnvelope): string {
+    const salt = Buffer.from(envelope.saltHex, 'hex');
+    const iv = Buffer.from(envelope.ivHex, 'hex');
+    const ct = Buffer.from(envelope.ciphertextHex, 'hex');
+    const tag = Buffer.from(envelope.tagHex, 'hex');
+    const key = this.deriveKey(salt);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
+  }
+
+  private deriveKey(salt: Buffer): Buffer {
+    const material = `${this.machineId}|filemakerDataApiTools`;
+    return crypto.pbkdf2Sync(material, salt, 100_000, 32, 'sha256');
+  }
+}
+
+function maskKey(key: string): string {
+  const idx = key.lastIndexOf('.');
+  return idx > 0 ? `${key.slice(0, idx)}.***` : '***';
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
   }
 }

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 
 import type { EnterpriseRole, PerformanceMode, SavedQueryScope, SchemaSnapshotStorage } from '../types/fm';
 import type { LogLevel } from './logger';
+import type { SecretFallbackMode } from './secretStore';
 
 interface SettingsServiceOptions {
   getConfiguration?: (section?: string) => vscode.WorkspaceConfiguration;
@@ -184,6 +185,17 @@ export class SettingsService {
 
   public isTelemetryEnabled(): boolean {
     return this.getConfiguration('filemaker').get<boolean>('telemetry.enabled', false);
+  }
+
+  public getSecretsFallbackMode(): SecretFallbackMode {
+    const configured = this.getConfiguration('filemaker').get<string>(
+      'secrets.fallback',
+      'vscode-only'
+    );
+    if (configured === 'workspace-state' || configured === 'disabled') {
+      return configured;
+    }
+    return 'vscode-only';
   }
 }
 

--- a/extension/test/unit/secretStore.test.ts
+++ b/extension/test/unit/secretStore.test.ts
@@ -1,25 +1,213 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SecretStore } from '../../src/services/secretStore';
-import { InMemorySecretStorage } from './mocks';
+import { InMemoryMemento, InMemorySecretStorage } from './mocks';
+
+class FailingSecretStorage {
+  public storeFailures = 0;
+  public getFailures = 0;
+  public deleteFailures = 0;
+
+  public async storeSecret(_key: string, _value: string): Promise<void> {
+    this.storeFailures += 1;
+    throw new Error('SecretStorage unavailable: store');
+  }
+
+  public async store(_key: string, _value: string): Promise<void> {
+    this.storeFailures += 1;
+    throw new Error('SecretStorage unavailable: store');
+  }
+
+  public async get(_key: string): Promise<string | undefined> {
+    this.getFailures += 1;
+    throw new Error('SecretStorage unavailable: get');
+  }
+
+  public async delete(_key: string): Promise<void> {
+    this.deleteFailures += 1;
+    throw new Error('SecretStorage unavailable: delete');
+  }
+}
+
+function createSilentLogger(): { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } {
+  return {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn()
+  };
+}
 
 describe('SecretStore', () => {
-  it('stores and retrieves profile secrets', async () => {
-    const storage = new InMemorySecretStorage();
-    const store = new SecretStore(storage as never);
+  describe('vscode-only mode (default)', () => {
+    it('stores and retrieves profile secrets when SecretStorage works', async () => {
+      const storage = new InMemorySecretStorage();
+      const store = new SecretStore(storage as never);
 
-    await store.setPassword('profile-1', 'pass-1');
-    await store.setSessionToken('profile-1', 'token-1');
-    await store.setProxyApiKey('profile-1', 'proxy-1');
+      await store.setPassword('profile-1', 'pass-1');
+      await store.setSessionToken('profile-1', 'token-1');
+      await store.setProxyApiKey('profile-1', 'proxy-1');
 
-    await expect(store.getPassword('profile-1')).resolves.toBe('pass-1');
-    await expect(store.getSessionToken('profile-1')).resolves.toBe('token-1');
-    await expect(store.getProxyApiKey('profile-1')).resolves.toBe('proxy-1');
+      await expect(store.getPassword('profile-1')).resolves.toBe('pass-1');
+      await expect(store.getSessionToken('profile-1')).resolves.toBe('token-1');
+      await expect(store.getProxyApiKey('profile-1')).resolves.toBe('proxy-1');
 
-    await store.clearProfileSecrets('profile-1');
+      await store.clearProfileSecrets('profile-1');
 
-    await expect(store.getPassword('profile-1')).resolves.toBeUndefined();
-    await expect(store.getSessionToken('profile-1')).resolves.toBeUndefined();
-    await expect(store.getProxyApiKey('profile-1')).resolves.toBeUndefined();
+      await expect(store.getPassword('profile-1')).resolves.toBeUndefined();
+      await expect(store.getSessionToken('profile-1')).resolves.toBeUndefined();
+      await expect(store.getProxyApiKey('profile-1')).resolves.toBeUndefined();
+    });
+
+    it('propagates errors when SecretStorage throws and no fallback configured', async () => {
+      const failing = new FailingSecretStorage();
+      const store = new SecretStore(failing as never);
+
+      await expect(store.setPassword('p', 'x')).rejects.toThrow(/SecretStorage unavailable/);
+      await expect(store.getPassword('p')).rejects.toThrow(/SecretStorage unavailable/);
+      await expect(store.deletePassword('p')).rejects.toThrow(/SecretStorage unavailable/);
+    });
+  });
+
+  describe('workspace-state fallback mode', () => {
+    let memento: InMemoryMemento;
+    let logger: ReturnType<typeof createSilentLogger>;
+    let onFallbackEngaged: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      memento = new InMemoryMemento();
+      logger = createSilentLogger();
+      onFallbackEngaged = vi.fn();
+    });
+
+    it('throws at construction when workspaceState is missing', () => {
+      const storage = new InMemorySecretStorage();
+      expect(() => new SecretStore(storage as never, { fallbackMode: 'workspace-state' })).toThrow(
+        /requires options.workspaceState/
+      );
+    });
+
+    it('uses encrypted Memento when SecretStorage.store fails', async () => {
+      const failing = new FailingSecretStorage();
+      const store = new SecretStore(failing as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-A',
+        logger,
+        onFallbackEngaged
+      });
+
+      await store.setPassword('p1', 'super-secret');
+      await expect(store.getPassword('p1')).resolves.toBe('super-secret');
+
+      // Persisted as encrypted envelope, not plaintext
+      const map = memento.get<Record<string, unknown>>('filemakerDataApiTools.fallbackSecrets.v1') ?? {};
+      const keys = Object.keys(map);
+      expect(keys).toHaveLength(1);
+      const envelope = map[keys[0]] as Record<string, string>;
+      expect(envelope.ciphertextHex).toBeDefined();
+      expect(envelope.ciphertextHex).not.toContain('super-secret');
+      expect(envelope.tagHex).toBeDefined();
+      expect(envelope.ivHex).toBeDefined();
+
+      // Engaged callback fires once per instance
+      expect(onFallbackEngaged).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalled();
+
+      // A second failed call does not re-fire the callback
+      await store.setSessionToken('p1', 'tok-1');
+      expect(onFallbackEngaged).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads from fallback when SecretStorage.get throws', async () => {
+      const failing = new FailingSecretStorage();
+      const store = new SecretStore(failing as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-A',
+        logger,
+        onFallbackEngaged
+      });
+
+      await store.setPassword('p2', 'hello');
+      await expect(store.getPassword('p2')).resolves.toBe('hello');
+      await store.deletePassword('p2');
+      await expect(store.getPassword('p2')).resolves.toBeUndefined();
+    });
+
+    it('returns undefined and logs error when ciphertext was written by a different machineId', async () => {
+      // Write with machine-A
+      const failing = new FailingSecretStorage();
+      const writer = new SecretStore(failing as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-A',
+        logger,
+        onFallbackEngaged
+      });
+      await writer.setPassword('p3', 'private');
+
+      // Read with machine-B (different machine, same workspaceState)
+      const reader = new SecretStore(failing as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-B',
+        logger,
+        onFallbackEngaged
+      });
+      await expect(reader.getPassword('p3')).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('successful primary write supersedes prior fallback entry', async () => {
+      const flaky = new InMemorySecretStorage();
+      const failing = new FailingSecretStorage();
+      // First write fails: store falls back
+      const store1 = new SecretStore(failing as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-A',
+        logger,
+        onFallbackEngaged
+      });
+      await store1.setPassword('p4', 'old-via-fallback');
+
+      // Second write succeeds via working SecretStorage; fallback entry should clear
+      const store2 = new SecretStore(flaky as never, {
+        fallbackMode: 'workspace-state',
+        workspaceState: memento as never,
+        machineId: 'machine-A',
+        logger,
+        onFallbackEngaged
+      });
+      await store2.setPassword('p4', 'new-via-primary');
+
+      const map =
+        memento.get<Record<string, unknown>>('filemakerDataApiTools.fallbackSecrets.v1') ?? {};
+      expect(Object.keys(map)).toHaveLength(0);
+    });
+  });
+
+  describe('disabled mode', () => {
+    it('skips persistence and returns undefined for reads', async () => {
+      const storage = new InMemorySecretStorage();
+      const logger = createSilentLogger();
+      const store = new SecretStore(storage as never, {
+        fallbackMode: 'disabled',
+        logger
+      });
+
+      await store.setPassword('p5', 'should-not-store');
+      await expect(store.getPassword('p5')).resolves.toBeUndefined();
+
+      // Underlying storage was never touched
+      const internal = await storage.get('filemakerDataApiTools.profile.password.p5');
+      expect(internal).toBeUndefined();
+
+      // Disabled deletes are no-ops, do not throw
+      await expect(store.deletePassword('p5')).resolves.toBeUndefined();
+
+      // Set was logged as skipped
+      expect(logger.warn).toHaveBeenCalled();
+    });
   });
 });

--- a/extension/test/unit/secretStore.test.ts
+++ b/extension/test/unit/secretStore.test.ts
@@ -8,22 +8,22 @@ class FailingSecretStorage {
   public getFailures = 0;
   public deleteFailures = 0;
 
-  public async storeSecret(_key: string, _value: string): Promise<void> {
+  public async storeSecret(): Promise<void> {
     this.storeFailures += 1;
     throw new Error('SecretStorage unavailable: store');
   }
 
-  public async store(_key: string, _value: string): Promise<void> {
+  public async store(): Promise<void> {
     this.storeFailures += 1;
     throw new Error('SecretStorage unavailable: store');
   }
 
-  public async get(_key: string): Promise<string | undefined> {
+  public async get(): Promise<string | undefined> {
     this.getFailures += 1;
     throw new Error('SecretStorage unavailable: get');
   }
 
-  public async delete(_key: string): Promise<void> {
+  public async delete(): Promise<void> {
     this.deleteFailures += 1;
     throw new Error('SecretStorage unavailable: delete');
   }


### PR DESCRIPTION
## Summary
SecretStore previously wrapped \`vscode.SecretStorage\` directly with no error handling. In headless CI, remote-agent failures, or any environment where SecretStorage is unavailable, every credential operation throws and the extension is unusable.

This PR adds:
- \`filemaker.secrets.fallback\` setting (\`vscode-only\` | \`workspace-state\` | \`disabled\`, default \`vscode-only\`)
- AES-256-GCM encryption with PBKDF2-100k key derivation from \`vscode.env.machineId\` + per-record salt for the workspace-state fallback
- One-time warning toast on first fallback engagement; every fallback use is logged
- Tests covering SecretStorage available, SecretStorage throws + fallback used, machineId-mismatch graceful failure, disabled mode, construction guard, primary-write supersedes-fallback

## Why machineId in the key derivation
If a workspace state file is moved to a different machine, the secrets won't decrypt — graceful degradation rather than data exposure. AuthTag from GCM ensures tampering is detected.

## Local validation
Sandbox \`npm install\` keeps getting killed by the runtime, so this relies on CI to validate (\`npm run typecheck\` + \`npm run test:coverage\` per ticket).

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)