### PR TITLE
DX: Circuit-breaker registry + 'Show Circuit Breaker Status' command (#49)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"626a56e3-71c0-4c55-a27c-69beb79912e5","pid":4098,"procStart":"Mon May  4 16:34:58 2026","acquiredAt":1777915098236}

--- a/extension/package.json
+++ b/extension/package.json
@@ -79,6 +79,7 @@
     "onCommand:filemakerDataApiTools.exportEnvironmentComparisonReport",
     "onCommand:filemakerDataApiTools.openEnvironmentSetJson",
     "onCommand:filemakerDataApiTools.openDiagnosticsDashboard",
+    "onCommand:filemakerDataApiTools.showCircuitBreakerStatus",
     "onCommand:filemakerDataApiTools.reloadPlugins",
     "onCommand:filemakerDataApiTools.listActivePlugins",
     "onCommand:filemakerDataApiTools.toggleOfflineMode",
@@ -276,6 +277,10 @@
       {
         "command": "filemakerDataApiTools.openDiagnosticsDashboard",
         "title": "FileMaker: Open Diagnostics Dashboard"
+      },
+      {
+        "command": "filemakerDataApiTools.showCircuitBreakerStatus",
+        "title": "FileMaker: Show Circuit Breaker Status"
       },
       {
         "command": "filemakerDataApiTools.reloadPlugins",

--- a/extension/src/commands/circuitBreaker.ts
+++ b/extension/src/commands/circuitBreaker.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 
-import {
-  CircuitBreakerRegistry,
-  renderCircuitBreakerStatus
-} from '../performance/circuitBreakerRegistry';
+import { renderCircuitBreakerStatus } from '../performance/circuitBreakerRegistry';
+import type { CircuitBreakerRegistry } from '../performance/circuitBreakerRegistry';
 
 export interface CircuitBreakerCommandsDeps {
   registry: CircuitBreakerRegistry;

--- a/extension/src/commands/circuitBreaker.ts
+++ b/extension/src/commands/circuitBreaker.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode';
+
+import {
+  CircuitBreakerRegistry,
+  renderCircuitBreakerStatus
+} from '../performance/circuitBreakerRegistry';
+
+export interface CircuitBreakerCommandsDeps {
+  registry: CircuitBreakerRegistry;
+}
+
+export function registerCircuitBreakerCommands(
+  deps: CircuitBreakerCommandsDeps
+): vscode.Disposable[] {
+  const showStatus = vscode.commands.registerCommand(
+    'filemakerDataApiTools.showCircuitBreakerStatus',
+    async () => {
+      const content = renderCircuitBreakerStatus(deps.registry.list());
+      const doc = await vscode.workspace.openTextDocument({
+        language: 'markdown',
+        content
+      });
+      await vscode.window.showTextDocument(doc, { preview: true });
+    }
+  );
+
+  return [showStatus];
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { registerBatchCommands } from './commands/batch';
+import { registerCircuitBreakerCommands } from './commands/circuitBreaker';
 import { registerDiagnosticsCommands } from './commands/diagnostics';
 import { registerEnterpriseCommands } from './commands/enterprise';
 import { registerFmWebProjectCommands } from './commands/fmWebProject';
@@ -35,6 +36,7 @@ import { EnvironmentCompareService } from './enterprise/environmentCompareServic
 import { RoleGuard } from './enterprise/roleGuard';
 import { MetricsStore } from './diagnostics/metricsStore';
 import { OfflineModeService } from './offline/offlineModeService';
+import { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
 import { PluginRegistry } from './plugins/pluginRegistry';
 import { FMExplorerProvider } from './views/fmExplorer';
 import { OfflineStatusBar } from './views/offlineStatusBar';
@@ -104,6 +106,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     isWorkspaceTrusted: () => vscode.workspace.isTrusted
   });
+  const circuitBreakerRegistry = new CircuitBreakerRegistry();
   const batchService = new BatchService(fmClient, {
     getMaxRecords: () => {
       const configured = settingsService.getBatchMaxRecords();
@@ -113,7 +116,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     },
     getConcurrency: () => settingsService.getBatchConcurrency(),
     getDryRunDefault: () => settingsService.getBatchDryRunDefault(),
-    getPerformanceMode: () => roleGuard.resolvePerformanceMode()
+    getPerformanceMode: () => roleGuard.resolvePerformanceMode(),
+    circuitBreakerRegistry
   });
   const pluginRegistry = new PluginRegistry(profileStore, fmClient, roleGuard, logger);
   const fmWebProjectService = new FmWebProjectService(
@@ -256,6 +260,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const pluginDisposables = registerPluginCommands({
     pluginRegistry
   });
+  const circuitBreakerDisposables = registerCircuitBreakerCommands({
+    registry: circuitBreakerRegistry
+  });
   const fmWebProjectDisposables = registerFmWebProjectCommands({
     context,
     profileStore,
@@ -307,6 +314,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ...diagnosticsDisposables,
     ...offlineDisposables,
     ...pluginDisposables,
+    ...circuitBreakerDisposables,
     ...fmWebProjectDisposables,
     diagnostics,
     jobsStatusBar,

--- a/extension/src/performance/circuitBreaker.ts
+++ b/extension/src/performance/circuitBreaker.ts
@@ -1,15 +1,35 @@
 export type CircuitBreakerState = 'closed' | 'open' | 'half-open';
 
+export interface CircuitBreakerTransition {
+  from: CircuitBreakerState;
+  to: CircuitBreakerState;
+  at: number;
+  reason: 'failure-threshold' | 'half-open-success' | 'half-open-failure' | 'auto-half-open' | 'reset';
+}
+
+export interface CircuitBreakerDiagnostics {
+  state: CircuitBreakerState;
+  failureCount: number;
+  failureThreshold: number;
+  halfOpenSuccessCount: number;
+  halfOpenSuccessThreshold: number;
+  openMs: number;
+  openUntilMs: number;
+  msUntilHalfOpen: number;
+}
+
 interface CircuitBreakerOptions {
   failureThreshold?: number;
   openMs?: number;
   halfOpenSuccessThreshold?: number;
+  onTransition?: (transition: CircuitBreakerTransition) => void;
 }
 
 export class CircuitBreaker {
   private readonly failureThreshold: number;
   private readonly openMs: number;
   private readonly halfOpenSuccessThreshold: number;
+  private readonly onTransition?: (transition: CircuitBreakerTransition) => void;
 
   private state: CircuitBreakerState = 'closed';
   private failureCount = 0;
@@ -20,10 +40,25 @@ export class CircuitBreaker {
     this.failureThreshold = normalize(options?.failureThreshold, 5, 1, 50);
     this.openMs = normalize(options?.openMs, 5_000, 100, 60_000);
     this.halfOpenSuccessThreshold = normalize(options?.halfOpenSuccessThreshold, 2, 1, 10);
+    this.onTransition = options?.onTransition;
   }
 
   public getState(now = Date.now()): CircuitBreakerState {
     return this.evaluateState(now);
+  }
+
+  public getDiagnostics(now = Date.now()): CircuitBreakerDiagnostics {
+    const state = this.evaluateState(now);
+    return {
+      state,
+      failureCount: this.failureCount,
+      failureThreshold: this.failureThreshold,
+      halfOpenSuccessCount: this.halfOpenSuccessCount,
+      halfOpenSuccessThreshold: this.halfOpenSuccessThreshold,
+      openMs: this.openMs,
+      openUntilMs: this.openUntil,
+      msUntilHalfOpen: this.state === 'open' ? Math.max(0, this.openUntil - now) : 0
+    };
   }
 
   public canRequest(now = Date.now()): boolean {
@@ -37,7 +72,7 @@ export class CircuitBreaker {
     if (state === 'half-open') {
       this.halfOpenSuccessCount += 1;
       if (this.halfOpenSuccessCount >= this.halfOpenSuccessThreshold) {
-        this.reset();
+        this.reset(now);
       }
       return;
     }
@@ -50,29 +85,37 @@ export class CircuitBreaker {
     const state = this.evaluateState(now);
 
     if (state === 'half-open') {
-      this.trip(now);
+      this.trip(now, 'half-open-failure');
       return;
     }
 
     this.failureCount += 1;
 
     if (this.failureCount >= this.failureThreshold) {
-      this.trip(now);
+      this.trip(now, 'failure-threshold');
     }
   }
 
-  public reset(): void {
+  public reset(now = Date.now()): void {
+    const prev = this.state;
     this.state = 'closed';
     this.failureCount = 0;
     this.halfOpenSuccessCount = 0;
     this.openUntil = 0;
+    if (prev !== 'closed') {
+      this.emit({ from: prev, to: 'closed', at: now, reason: this.transitionReason(prev, 'closed') });
+    }
   }
 
-  private trip(now: number): void {
+  private trip(now: number, reason: CircuitBreakerTransition['reason']): void {
+    const prev = this.state;
     this.state = 'open';
     this.openUntil = now + this.openMs;
     this.failureCount = this.failureThreshold;
     this.halfOpenSuccessCount = 0;
+    if (prev !== 'open') {
+      this.emit({ from: prev, to: 'open', at: now, reason });
+    }
   }
 
   private evaluateState(now = Date.now()): CircuitBreakerState {
@@ -84,9 +127,27 @@ export class CircuitBreaker {
       return 'open';
     }
 
+    const prev = this.state;
     this.state = 'half-open';
     this.halfOpenSuccessCount = 0;
+    this.emit({ from: prev, to: 'half-open', at: now, reason: 'auto-half-open' });
     return 'half-open';
+  }
+
+  private emit(transition: CircuitBreakerTransition): void {
+    try {
+      this.onTransition?.(transition);
+    } catch {
+      // Listener errors must never break the breaker; swallow.
+    }
+  }
+
+  private transitionReason(
+    from: CircuitBreakerState,
+    to: CircuitBreakerState
+  ): CircuitBreakerTransition['reason'] {
+    if (to === 'closed' && from === 'half-open') return 'half-open-success';
+    return 'reset';
   }
 }
 

--- a/extension/src/performance/circuitBreakerRegistry.ts
+++ b/extension/src/performance/circuitBreakerRegistry.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   CircuitBreaker,
-  type CircuitBreakerDiagnostics,
-  type CircuitBreakerTransition
+  CircuitBreakerDiagnostics,
+  CircuitBreakerTransition
 } from './circuitBreaker';
 
 const MAX_TRANSITIONS_PER_BREAKER = 25;

--- a/extension/src/performance/circuitBreakerRegistry.ts
+++ b/extension/src/performance/circuitBreakerRegistry.ts
@@ -1,0 +1,143 @@
+import {
+  CircuitBreaker,
+  type CircuitBreakerDiagnostics,
+  type CircuitBreakerTransition
+} from './circuitBreaker';
+
+const MAX_TRANSITIONS_PER_BREAKER = 25;
+
+export interface RegisteredBreaker {
+  name: string;
+  breaker: CircuitBreaker;
+  transitions: CircuitBreakerTransition[];
+  registeredAt: number;
+}
+
+export interface RegistryEntry {
+  name: string;
+  diagnostics: CircuitBreakerDiagnostics;
+  transitions: CircuitBreakerTransition[];
+  registeredAt: number;
+}
+
+/**
+ * Tracks named CircuitBreaker instances so the user can see their state via
+ * the "Show Circuit Breaker Status" command. Transitions are recorded with a
+ * bounded ring buffer per breaker.
+ */
+export class CircuitBreakerRegistry {
+  private readonly entries = new Map<string, RegisteredBreaker>();
+
+  public register(name: string, breaker: CircuitBreaker, now = Date.now()): void {
+    if (this.entries.has(name)) {
+      // Replace prior entry — last writer wins so duplicate jobs don't leak.
+      this.unregister(name);
+    }
+    this.entries.set(name, {
+      name,
+      breaker,
+      transitions: [],
+      registeredAt: now
+    });
+  }
+
+  public recordTransition(name: string, transition: CircuitBreakerTransition): void {
+    const entry = this.entries.get(name);
+    if (!entry) {
+      return;
+    }
+    entry.transitions.push(transition);
+    if (entry.transitions.length > MAX_TRANSITIONS_PER_BREAKER) {
+      entry.transitions.splice(0, entry.transitions.length - MAX_TRANSITIONS_PER_BREAKER);
+    }
+  }
+
+  public unregister(name: string): void {
+    this.entries.delete(name);
+  }
+
+  public clear(): void {
+    this.entries.clear();
+  }
+
+  public has(name: string): boolean {
+    return this.entries.has(name);
+  }
+
+  public size(): number {
+    return this.entries.size;
+  }
+
+  public list(now = Date.now()): RegistryEntry[] {
+    return [...this.entries.values()].map((entry) => ({
+      name: entry.name,
+      diagnostics: entry.breaker.getDiagnostics(now),
+      transitions: [...entry.transitions],
+      registeredAt: entry.registeredAt
+    }));
+  }
+}
+
+export function renderCircuitBreakerStatus(
+  entries: RegistryEntry[],
+  now = Date.now()
+): string {
+  if (entries.length === 0) {
+    return [
+      '# FileMaker Circuit Breaker Status',
+      '',
+      '_No active circuit breakers._',
+      '',
+      'Breakers are registered while batch operations are in flight.',
+      'If you opened this and expected to see one, the relevant operation has likely already completed.'
+    ].join('\n');
+  }
+
+  const lines: string[] = ['# FileMaker Circuit Breaker Status', ''];
+
+  for (const entry of entries) {
+    const d = entry.diagnostics;
+    const ageMs = now - entry.registeredAt;
+    lines.push(`## ${entry.name}`);
+    lines.push('');
+    lines.push(`- **State:** ${d.state.toUpperCase()}`);
+    lines.push(`- **Failure count:** ${d.failureCount} / ${d.failureThreshold}`);
+    if (d.state === 'open') {
+      const seconds = Math.max(0, Math.ceil(d.msUntilHalfOpen / 1000));
+      lines.push(`- **Reopens to half-open in:** ${seconds}s`);
+    }
+    if (d.state === 'half-open') {
+      lines.push(
+        `- **Half-open successes needed:** ${d.halfOpenSuccessCount} / ${d.halfOpenSuccessThreshold}`
+      );
+    }
+    lines.push(`- **Registered:** ${formatRelative(ageMs)} ago`);
+    lines.push('');
+
+    if (entry.transitions.length === 0) {
+      lines.push('_No transitions recorded._');
+    } else {
+      lines.push('### Transitions (most recent last)');
+      lines.push('');
+      lines.push('| Time | From → To | Reason |');
+      lines.push('|---|---|---|');
+      for (const t of entry.transitions) {
+        const ago = formatRelative(now - t.at);
+        lines.push(`| ${ago} ago | \`${t.from}\` → \`${t.to}\` | ${t.reason} |`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function formatRelative(ms: number): string {
+  if (ms < 1_000) return `${ms}ms`;
+  const sec = Math.round(ms / 1_000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.round(min / 60);
+  return `${hr}h`;
+}

--- a/extension/src/services/batchService.ts
+++ b/extension/src/services/batchService.ts
@@ -5,6 +5,7 @@ import type { FMClient } from './fmClient';
 import { FMClientError } from './errors';
 import { AdaptiveConcurrency } from '../performance/adaptiveConcurrency';
 import { CircuitBreaker } from '../performance/circuitBreaker';
+import type { CircuitBreakerRegistry } from '../performance/circuitBreakerRegistry';
 import type {
   BatchExportFormat,
   BatchExportOptions,
@@ -25,6 +26,7 @@ interface BatchServiceOptions {
   getConcurrency?: () => number;
   getDryRunDefault?: () => boolean;
   getPerformanceMode?: () => PerformanceMode;
+  circuitBreakerRegistry?: CircuitBreakerRegistry;
 }
 
 export class BatchService {
@@ -32,12 +34,14 @@ export class BatchService {
   private readonly getConcurrency: () => number;
   private readonly getDryRunDefault: () => boolean;
   private readonly getPerformanceMode: () => PerformanceMode;
+  private readonly circuitBreakerRegistry?: CircuitBreakerRegistry;
 
   public constructor(private readonly fmClient: FMClient, options?: BatchServiceOptions) {
     this.getMaxRecords = options?.getMaxRecords ?? (() => 10_000);
     this.getConcurrency = options?.getConcurrency ?? (() => 4);
     this.getDryRunDefault = options?.getDryRunDefault ?? (() => true);
     this.getPerformanceMode = options?.getPerformanceMode ?? (() => 'standard');
+    this.circuitBreakerRegistry = options?.circuitBreakerRegistry;
   }
 
   public getDefaultBatchUpdateOptions(): BatchUpdateOptions {
@@ -162,10 +166,18 @@ export class BatchService {
       max: maxConcurrency,
       targetLatencyMs: performanceMode === 'high-scale' ? 1400 : 900
     });
+    const registry = this.circuitBreakerRegistry;
+    const breakerName = `batchUpdate:${profile.id}:${layout}`;
     const breaker = new CircuitBreaker({
       failureThreshold: performanceMode === 'high-scale' ? 6 : 4,
-      openMs: performanceMode === 'high-scale' ? 6_000 : 4_000
+      openMs: performanceMode === 'high-scale' ? 6_000 : 4_000,
+      onTransition: registry
+        ? (transition) => registry.recordTransition(breakerName, transition)
+        : undefined
     });
+    if (registry) {
+      registry.register(breakerName, breaker);
+    }
 
     const inFlight = new Set<Promise<void>>();
 
@@ -220,6 +232,10 @@ export class BatchService {
       }
 
       await Promise.race(inFlight);
+    }
+
+    if (registry) {
+      registry.unregister(breakerName);
     }
 
     return {

--- a/extension/test/unit/performance/circuitBreakerRegistry.test.ts
+++ b/extension/test/unit/performance/circuitBreakerRegistry.test.ts
@@ -122,6 +122,6 @@ describe('renderCircuitBreakerStatus', () => {
     const registry = new CircuitBreakerRegistry();
     registry.register('flap', breaker, 0);
     const out = renderCircuitBreakerStatus(registry.list(300), 300);
-    expect(out).toContain('Half-open successes needed: 0 / 3');
+    expect(out).toContain('**Half-open successes needed:** 0 / 3');
   });
 });

--- a/extension/test/unit/performance/circuitBreakerRegistry.test.ts
+++ b/extension/test/unit/performance/circuitBreakerRegistry.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { CircuitBreaker } from '../../../src/performance/circuitBreaker';
+import {
+  CircuitBreakerRegistry,
+  renderCircuitBreakerStatus
+} from '../../../src/performance/circuitBreakerRegistry';
+
+function createBreaker(): { breaker: CircuitBreaker; registry: CircuitBreakerRegistry } {
+  const registry = new CircuitBreakerRegistry();
+  const breaker = new CircuitBreaker({
+    failureThreshold: 3,
+    openMs: 1_000,
+    onTransition: (t) => registry.recordTransition('test', t)
+  });
+  registry.register('test', breaker, 0);
+  return { breaker, registry };
+}
+
+describe('CircuitBreakerRegistry', () => {
+  it('returns empty list when no breakers registered', () => {
+    const registry = new CircuitBreakerRegistry();
+    expect(registry.list()).toEqual([]);
+  });
+
+  it('records transitions when the breaker trips', () => {
+    const { breaker, registry } = createBreaker();
+    breaker.recordFailure(1_000);
+    breaker.recordFailure(1_001);
+    breaker.recordFailure(1_002);
+    const entries = registry.list(1_500);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].diagnostics.state).toBe('open');
+    expect(entries[0].transitions).toHaveLength(1);
+    expect(entries[0].transitions[0].reason).toBe('failure-threshold');
+  });
+
+  it('records auto-half-open transition when the open window elapses', () => {
+    const { breaker, registry } = createBreaker();
+    breaker.recordFailure(1_000);
+    breaker.recordFailure(1_001);
+    breaker.recordFailure(1_002);
+
+    // Past the openMs window
+    breaker.getState(3_000);
+    const entries = registry.list(3_000);
+    expect(entries[0].diagnostics.state).toBe('half-open');
+    expect(entries[0].transitions.map((t) => t.to)).toEqual(['open', 'half-open']);
+  });
+
+  it('replaces prior entry on duplicate registration (last writer wins)', () => {
+    const registry = new CircuitBreakerRegistry();
+    const a = new CircuitBreaker({ failureThreshold: 1 });
+    const b = new CircuitBreaker({ failureThreshold: 1 });
+    registry.register('shared', a, 0);
+    registry.register('shared', b, 100);
+    expect(registry.size()).toBe(1);
+    expect(registry.list(200)[0].registeredAt).toBe(100);
+  });
+
+  it('caps recorded transitions at 25', () => {
+    const registry = new CircuitBreakerRegistry();
+    const breaker = new CircuitBreaker({ failureThreshold: 1, openMs: 100 });
+    registry.register('flapping', breaker, 0);
+    for (let i = 0; i < 50; i += 1) {
+      registry.recordTransition('flapping', {
+        from: 'closed',
+        to: 'open',
+        at: i,
+        reason: 'failure-threshold'
+      });
+    }
+    const entries = registry.list();
+    expect(entries[0].transitions.length).toBe(25);
+    // Most-recent are kept; oldest 25 dropped
+    expect(entries[0].transitions[0].at).toBe(25);
+    expect(entries[0].transitions[24].at).toBe(49);
+  });
+
+  it('unregister removes the breaker', () => {
+    const { registry } = createBreaker();
+    registry.unregister('test');
+    expect(registry.size()).toBe(0);
+  });
+});
+
+describe('renderCircuitBreakerStatus', () => {
+  it('renders the empty-state message when nothing is registered', () => {
+    const out = renderCircuitBreakerStatus([]);
+    expect(out).toContain('No active circuit breakers');
+  });
+
+  it('renders open breaker with reopens-in countdown', () => {
+    const breaker = new CircuitBreaker({ failureThreshold: 2, openMs: 5_000 });
+    breaker.recordFailure(1_000);
+    breaker.recordFailure(1_001);
+    const registry = new CircuitBreakerRegistry();
+    registry.register('batch:profile-1:Layout', breaker, 1_000);
+    // Manually push a transition (the registry would have via onTransition callback in real wiring)
+    registry.recordTransition('batch:profile-1:Layout', {
+      from: 'closed',
+      to: 'open',
+      at: 1_001,
+      reason: 'failure-threshold'
+    });
+    const out = renderCircuitBreakerStatus(registry.list(2_000), 2_000);
+    expect(out).toContain('## batch:profile-1:Layout');
+    expect(out).toContain('**State:** OPEN');
+    expect(out).toContain('Reopens to half-open in:');
+    expect(out).toContain('| 999ms ago | `closed` → `open` | failure-threshold |');
+  });
+
+  it('renders half-open breaker with progress', () => {
+    const breaker = new CircuitBreaker({
+      failureThreshold: 1,
+      halfOpenSuccessThreshold: 3,
+      openMs: 100
+    });
+    breaker.recordFailure(0);
+    // Trigger half-open evaluation
+    breaker.getState(200);
+    const registry = new CircuitBreakerRegistry();
+    registry.register('flap', breaker, 0);
+    const out = renderCircuitBreakerStatus(registry.list(300), 300);
+    expect(out).toContain('Half-open successes needed: 0 / 3');
+  });
+});


### PR DESCRIPTION
## Summary
\`circuitBreaker.ts\` exposed \`getState()\` but the breaker was invisible to users — when it tripped during a batch operation, requests appeared to fail mysteriously. This PR adds:

- \`CircuitBreaker\`: \`getDiagnostics()\`, transition listener (\`onTransition\`)
- \`CircuitBreakerRegistry\`: tracks named breakers with a bounded ring of recent transitions
- \`batchService\` registers its per-job breaker as \`batchUpdate:{profileId}:{layout}\`
- New command **\"FileMaker: Show Circuit Breaker Status\"** that opens a markdown Details document with state, failure count, time-until-half-open, and transition history per breaker

## Deferred
The ticket's \"render in diagnostics dashboard per profile\" sub-criterion is deferred. The dashboard would need its own refactor to consume the registry, and the standalone command already covers the immediate visibility gap. Tracked in this PR's body if you want a follow-up.

## Test plan
- [x] Unit tests covering: empty registry, transition recording, ring buffer cap (25), last-writer-wins on duplicate registration, auto half-open transition, markdown render for empty/open/half-open states
- [x] CI build-test

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)