### PR TITLE
Security: Harden webview message validation against malformed/oversized payloads (#50)

### DIFF
--- a/extension/src/webviews/common/messageValidation.ts
+++ b/extension/src/webviews/common/messageValidation.ts
@@ -1,5 +1,121 @@
 import type { WebviewMessageEnvelope } from '../../types/webviewMessages';
 
+/** Default upper bound on the JSON-serialized size of a single webview message. */
+export const DEFAULT_MAX_MESSAGE_BYTES = 1 * 1024 * 1024; // 1 MiB
+
+/** Default upper bound on the length of a single string field. Kept generous to allow find queries. */
+export const DEFAULT_MAX_STRING_FIELD_LENGTH = 64 * 1024; // 64 KiB
+
+/** Default upper bound on the depth of a message object. Anti-DoS guard. */
+export const DEFAULT_MAX_DEPTH = 16;
+
+export interface MessageValidationOptions {
+  maxBytes?: number;
+  maxDepth?: number;
+}
+
+export interface MessageValidationFailure {
+  ok: false;
+  reason:
+    | 'not-object'
+    | 'too-large'
+    | 'too-deep'
+    | 'prototype-pollution'
+    | 'circular'
+    | 'invalid-json';
+  detail?: string;
+}
+
+export interface MessageValidationSuccess {
+  ok: true;
+  record: Record<string, unknown>;
+}
+
+export type MessageValidationResult = MessageValidationSuccess | MessageValidationFailure;
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+/**
+ * Comprehensive structural validator for inbound webview messages. Returns a
+ * tagged result so callers don't throw and don't leak internal state on bad
+ * input. Pair with hasMessageType / getStringField / etc to extract typed
+ * fields after validation succeeds.
+ */
+export function validateEnvelope(
+  value: unknown,
+  options?: MessageValidationOptions
+): MessageValidationResult {
+  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_MESSAGE_BYTES;
+  const maxDepth = options?.maxDepth ?? DEFAULT_MAX_DEPTH;
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { ok: false, reason: 'not-object' };
+  }
+
+  // Size check uses JSON.stringify; circular references throw.
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof TypeError && /circular/i.test(err.message) ? 'circular' : 'invalid-json',
+      detail: err instanceof Error ? err.message : undefined
+    };
+  }
+
+  if (typeof serialized !== 'string') {
+    return { ok: false, reason: 'invalid-json' };
+  }
+
+  const byteLen = Buffer.byteLength(serialized, 'utf8');
+  if (byteLen > maxBytes) {
+    return { ok: false, reason: 'too-large', detail: `${byteLen} > ${maxBytes}` };
+  }
+
+  const depthCheck = checkDepthAndKeys(value, 0, maxDepth);
+  if (depthCheck) {
+    return depthCheck;
+  }
+
+  return { ok: true, record: value as Record<string, unknown> };
+}
+
+function checkDepthAndKeys(
+  value: unknown,
+  depth: number,
+  maxDepth: number
+): MessageValidationFailure | undefined {
+  if (depth > maxDepth) {
+    return { ok: false, reason: 'too-deep', detail: `depth ${depth} > ${maxDepth}` };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const sub = checkDepthAndKeys(item, depth + 1, maxDepth);
+      if (sub) return sub;
+    }
+    return undefined;
+  }
+
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      return { ok: false, reason: 'prototype-pollution', detail: `disallowed key: ${key}` };
+    }
+    const sub = checkDepthAndKeys(
+      (value as Record<string, unknown>)[key],
+      depth + 1,
+      maxDepth
+    );
+    if (sub) return sub;
+  }
+  return undefined;
+}
+
 export function toRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -18,10 +134,18 @@ export function hasMessageType<TType extends string>(
 
 export function getStringField(
   value: Record<string, unknown>,
-  field: string
+  field: string,
+  options?: { maxLength?: number }
 ): string | undefined {
   const raw = value[field];
-  return typeof raw === 'string' ? raw : undefined;
+  if (typeof raw !== 'string') {
+    return undefined;
+  }
+  const limit = options?.maxLength ?? DEFAULT_MAX_STRING_FIELD_LENGTH;
+  if (raw.length > limit) {
+    return undefined;
+  }
+  return raw;
 }
 
 export function getOptionalBooleanField(
@@ -34,8 +158,14 @@ export function getOptionalBooleanField(
 
 export function getOptionalNumberField(
   value: Record<string, unknown>,
-  field: string
+  field: string,
+  options?: { min?: number; max?: number }
 ): number | undefined {
   const raw = value[field];
-  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return undefined;
+  }
+  if (options?.min !== undefined && raw < options.min) return undefined;
+  if (options?.max !== undefined && raw > options.max) return undefined;
+  return raw;
 }

--- a/extension/test/unit/messageValidation.test.ts
+++ b/extension/test/unit/messageValidation.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DEFAULT_MAX_MESSAGE_BYTES,
+  DEFAULT_MAX_STRING_FIELD_LENGTH,
   getOptionalBooleanField,
   getOptionalNumberField,
   getStringField,
   hasMessageType,
-  toRecord
+  toRecord,
+  validateEnvelope
 } from '../../src/webviews/common/messageValidation';
 
-describe('messageValidation', () => {
+describe('messageValidation: type guards', () => {
   it('guards object records', () => {
     expect(toRecord(null)).toBeUndefined();
     expect(toRecord([])).toBeUndefined();
@@ -26,5 +29,103 @@ describe('messageValidation', () => {
     expect(getOptionalBooleanField(record, 'b')).toBe(true);
     expect(getOptionalNumberField(record, 'c')).toBe(42);
     expect(getOptionalNumberField(record, 'a')).toBeUndefined();
+  });
+
+  it('rejects oversized strings via getStringField', () => {
+    const record = { big: 'x'.repeat(DEFAULT_MAX_STRING_FIELD_LENGTH + 1) };
+    expect(getStringField(record, 'big')).toBeUndefined();
+    expect(getStringField(record, 'big', { maxLength: 10 })).toBeUndefined();
+    expect(getStringField({ small: 'hello' }, 'small', { maxLength: 10 })).toBe('hello');
+  });
+
+  it('enforces numeric range via getOptionalNumberField', () => {
+    const record = { n: 100 };
+    expect(getOptionalNumberField(record, 'n', { min: 0, max: 200 })).toBe(100);
+    expect(getOptionalNumberField(record, 'n', { min: 0, max: 50 })).toBeUndefined();
+    expect(getOptionalNumberField(record, 'n', { min: 200, max: 1000 })).toBeUndefined();
+    expect(getOptionalNumberField({ n: NaN }, 'n')).toBeUndefined();
+    expect(getOptionalNumberField({ n: Infinity }, 'n')).toBeUndefined();
+  });
+});
+
+describe('validateEnvelope', () => {
+  it('rejects non-objects', () => {
+    expect(validateEnvelope(null)).toEqual({ ok: false, reason: 'not-object' });
+    expect(validateEnvelope(undefined)).toEqual({ ok: false, reason: 'not-object' });
+    expect(validateEnvelope(42)).toEqual({ ok: false, reason: 'not-object' });
+    expect(validateEnvelope('string')).toEqual({ ok: false, reason: 'not-object' });
+    expect(validateEnvelope([])).toEqual({ ok: false, reason: 'not-object' });
+  });
+
+  it('accepts a well-formed message', () => {
+    const result = validateEnvelope({ type: 'ready', payload: { layout: 'Contacts' } });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.record.type).toBe('ready');
+    }
+  });
+
+  it('rejects messages exceeding the byte limit', () => {
+    const huge = { type: 'paste', body: 'x'.repeat(DEFAULT_MAX_MESSAGE_BYTES + 100) };
+    const result = validateEnvelope(huge);
+    expect(result).toMatchObject({ ok: false, reason: 'too-large' });
+  });
+
+  it('respects custom maxBytes', () => {
+    const result = validateEnvelope({ type: 'ready', body: 'hello world' }, { maxBytes: 5 });
+    expect(result).toMatchObject({ ok: false, reason: 'too-large' });
+  });
+
+  it('rejects deeply nested objects', () => {
+    let nested: Record<string, unknown> = { type: 'ready' };
+    for (let i = 0; i < 25; i += 1) {
+      nested = { child: nested };
+    }
+    const result = validateEnvelope(nested, { maxDepth: 16 });
+    expect(result).toMatchObject({ ok: false, reason: 'too-deep' });
+  });
+
+  it('rejects __proto__ key (prototype pollution attempt)', () => {
+    // Note: object literal { __proto__: ... } sets the prototype directly;
+    // use Object.defineProperty / JSON parse to inject it as an own property.
+    const malicious = JSON.parse('{"type":"ready","__proto__":{"polluted":true}}');
+    const result = validateEnvelope(malicious);
+    expect(result).toMatchObject({ ok: false, reason: 'prototype-pollution' });
+  });
+
+  it('rejects nested constructor key', () => {
+    const malicious = { type: 'ready', payload: { constructor: { evil: true } } };
+    const result = validateEnvelope(malicious);
+    expect(result).toMatchObject({ ok: false, reason: 'prototype-pollution' });
+  });
+
+  it('rejects circular references', () => {
+    const circ: Record<string, unknown> = { type: 'ready' };
+    circ.self = circ;
+    const result = validateEnvelope(circ);
+    expect(result).toMatchObject({ ok: false, reason: 'circular' });
+  });
+
+  it('walks arrays for forbidden keys', () => {
+    const malicious = {
+      type: 'ready',
+      items: [
+        { ok: true },
+        { __proto__: { polluted: true } }
+      ]
+    };
+    // Object literal short-circuits __proto__; force own-property via JSON.
+    const parsed = JSON.parse(JSON.stringify(malicious).replace('"items":', '"items":'));
+    // Re-inject __proto__ at array element via parsed JSON
+    const withInjected = JSON.parse(
+      '{"type":"ready","items":[{"ok":true},{"__proto__":{"polluted":true}}]}'
+    );
+    const result = validateEnvelope(withInjected);
+    expect(result).toMatchObject({ ok: false, reason: 'prototype-pollution' });
+    // Smoke check: the safe message above is OK
+    const safe = validateEnvelope({ type: 'ready', items: [{ ok: true }] });
+    expect(safe.ok).toBe(true);
+    // parsed isn't asserted on; this just exercises the array walk.
+    expect(parsed).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
Adds \`validateEnvelope()\` to webview messageValidation, returning a tagged result that covers:
- Non-object inputs
- Oversized payloads (default 1 MiB; configurable via \`maxBytes\`)
- Excessive nesting depth (default 16; DoS guard)
- Prototype-pollution attempts (\`__proto__\`, \`prototype\`, \`constructor\` as own properties anywhere in the tree)
- Circular references

Existing helpers gain bounds:
- \`getStringField\` now accepts a \`maxLength\` (default 64 KiB)
- \`getOptionalNumberField\` now accepts \`{ min, max }\` range guards (and rejects NaN/Infinity)

## Test plan
- [x] 13 unit tests covering each failure path and extended type-guard semantics
- [x] CI build-test

## Adoption
The new helpers are additive — existing webview controllers continue to compile. Wiring \`validateEnvelope\` into each controller's onMessage handler is left as follow-up (per controller, with appropriate \`maxBytes\` per use-case) so this PR stays scoped.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)