### PR TITLE
Reliability: Exponential backoff for FM login/createSession retries (#48)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -678,6 +678,34 @@
           "default": false,
           "description": "Enable anonymous usage telemetry to help improve the extension. No personal data or FileMaker credentials are collected."
         },
+        "filemaker.connect.maxRetries": {
+          "type": "number",
+          "default": 3,
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Number of retries the FileMaker connect command performs on transient login failures (network errors, 5xx). 0 disables retry."
+        },
+        "filemaker.connect.backoffInitialMs": {
+          "type": "number",
+          "default": 1000,
+          "minimum": 100,
+          "maximum": 60000,
+          "description": "Initial delay (ms) before the first retry of a failed connect."
+        },
+        "filemaker.connect.backoffMaxMs": {
+          "type": "number",
+          "default": 30000,
+          "minimum": 1000,
+          "maximum": 300000,
+          "description": "Maximum delay (ms) the connect backoff will wait between retries."
+        },
+        "filemaker.connect.backoffMultiplier": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Exponential multiplier applied to the connect backoff delay between retries."
+        },
         "filemaker.secrets.fallback": {
           "type": "string",
           "enum": [

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -23,6 +23,7 @@ import {
 import { ConnectionWizardPanel } from '../webviews/connectionWizard';
 import { QueryBuilderPanel } from '../webviews/queryBuilder';
 import { RecordViewerPanel } from '../webviews/recordViewer';
+import { retryWithBackoff, type BackoffPolicy } from '../utils/backoff';
 
 interface RegisterCoreCommandDeps {
   context: vscode.ExtensionContext;
@@ -34,6 +35,35 @@ interface RegisterCoreCommandDeps {
   roleGuard: RoleGuard;
   refreshExplorer: () => void;
   onProfileDisconnected?: (profileId: string) => void;
+  /** Resolved at call time so settings updates are picked up live. */
+  getConnectBackoffPolicy?: () => BackoffPolicy;
+}
+
+function isRetryableConnectError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { code?: string; status?: number; message?: string };
+  if (typeof err.code === 'string') {
+    if (
+      err.code === 'ECONNRESET' ||
+      err.code === 'ECONNREFUSED' ||
+      err.code === 'ETIMEDOUT' ||
+      err.code === 'ENOTFOUND' ||
+      err.code === 'EAI_AGAIN' ||
+      err.code === 'EPIPE' ||
+      err.code === 'ENETUNREACH'
+    ) {
+      return true;
+    }
+  }
+  if (typeof err.status === 'number' && err.status >= 500 && err.status < 600) {
+    return true;
+  }
+  if (typeof err.message === 'string') {
+    if (/timeout|network|socket|reset|refused/i.test(err.message)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disposable[] {
@@ -117,8 +147,39 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
         return;
       }
 
+      const policy: BackoffPolicy = deps.getConnectBackoffPolicy?.() ?? {
+        maxRetries: 3,
+        initialMs: 1_000,
+        maxMs: 30_000,
+        multiplier: 2
+      };
+
+      const statusBar = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left,
+        110
+      );
       try {
-        await fmClient.createSession(profile);
+        statusBar.text = `$(sync~spin) FileMaker: Connecting to ${profile.name}…`;
+        statusBar.show();
+
+        await retryWithBackoff(
+          () => fmClient.createSession(profile),
+          policy,
+          {
+            shouldRetry: (err) => isRetryableConnectError(err),
+            onRetry: ({ attempt, delayMs, error }) => {
+              const seconds = Math.max(1, Math.round(delayMs / 1000));
+              statusBar.text = `$(sync~spin) FileMaker: Connecting to ${profile.name} — retry ${attempt + 1}/${policy.maxRetries} in ${seconds}s`;
+              logger.warn('Connect attempt failed; retrying with backoff.', {
+                profileId: profile.id,
+                attempt,
+                delayMs,
+                error
+              });
+            }
+          }
+        );
+
         await profileStore.setActiveProfileId(profile.id);
         refreshExplorer();
         vscode.window.showInformationMessage(`Connected to "${profile.name}".`);
@@ -128,6 +189,8 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
           logger,
           logMessage: 'Connect command failed.'
         });
+      } finally {
+        statusBar.dispose();
       }
     }),
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -160,7 +160,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     refreshExplorer,
     onProfileDisconnected: (profileId) => {
       schemaService.invalidateProfile(profileId);
-    }
+    },
+    getConnectBackoffPolicy: () => settingsService.getConnectBackoffPolicy()
   });
 
   const savedQueryDisposables = registerSavedQueriesCommands({

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -195,6 +195,26 @@ export class SettingsService {
     return this.getConfiguration('filemaker').get<boolean>('telemetry.enabled', false);
   }
 
+  public getConnectBackoffPolicy(): {
+    maxRetries: number;
+    initialMs: number;
+    maxMs: number;
+    multiplier: number;
+  } {
+    const config = this.getConfiguration('filemaker');
+    const maxRetries = config.get<number>('connect.maxRetries', 3);
+    const initialMs = config.get<number>('connect.backoffInitialMs', 1_000);
+    const maxMs = config.get<number>('connect.backoffMaxMs', 30_000);
+    const multiplier = config.get<number>('connect.backoffMultiplier', 2);
+    return {
+      maxRetries: clamp(Number.isFinite(maxRetries) ? Math.round(maxRetries) : 3, 0, 10),
+      initialMs: clamp(Number.isFinite(initialMs) ? Math.round(initialMs) : 1_000, 100, 60_000),
+      maxMs: clamp(Number.isFinite(maxMs) ? Math.round(maxMs) : 30_000, 1_000, 300_000),
+      multiplier:
+        Number.isFinite(multiplier) && multiplier >= 1 ? Math.min(10, multiplier) : 2
+    };
+  }
+
   public getSecretsFallbackMode(): SecretFallbackMode {
     const configured = this.getConfiguration('filemaker').get<string>(
       'secrets.fallback',

--- a/extension/src/utils/backoff.ts
+++ b/extension/src/utils/backoff.ts
@@ -1,0 +1,77 @@
+export interface BackoffPolicy {
+  maxRetries: number;
+  initialMs: number;
+  maxMs: number;
+  multiplier: number;
+  /** Random factor between 0 and 1 for jitter; default 0.25 (±25%). */
+  jitter?: number;
+}
+
+/**
+ * Compute the delay (in ms) to wait before retry attempt N (0-indexed).
+ * Returns capped exponential backoff with optional jitter.
+ *
+ * Pure helper — does not sleep. Caller is responsible for the wait.
+ */
+export function computeBackoffDelayMs(
+  attemptIndex: number,
+  policy: BackoffPolicy,
+  random: () => number = Math.random
+): number {
+  const safeAttempt = Math.max(0, attemptIndex);
+  const base = policy.initialMs * Math.pow(policy.multiplier, safeAttempt);
+  const capped = Math.min(policy.maxMs, base);
+  const jitterFactor = policy.jitter ?? 0.25;
+  if (jitterFactor <= 0) {
+    return Math.max(0, Math.round(capped));
+  }
+  // Symmetric jitter: ±jitterFactor around capped.
+  const delta = capped * jitterFactor * (random() * 2 - 1);
+  return Math.max(0, Math.round(capped + delta));
+}
+
+export interface RetryHooks {
+  /** Decide whether to retry the given error. Default: always retry. */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  /** Called before each delay; useful for status-bar countdowns. */
+  onRetry?: (info: { attempt: number; delayMs: number; error: unknown }) => void;
+  /** Sleep implementation; defaulted to setTimeout. Tests inject a synchronous variant. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Random source; defaults to Math.random. */
+  random?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  policy: BackoffPolicy,
+  hooks?: RetryHooks
+): Promise<T> {
+  const sleep = hooks?.sleep ?? defaultSleep;
+  const random = hooks?.random ?? Math.random;
+  const shouldRetry = hooks?.shouldRetry ?? (() => true);
+
+  const totalAttempts = Math.max(1, policy.maxRetries + 1);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt === totalAttempts - 1 || !shouldRetry(error, attempt)) {
+        throw error;
+      }
+      const delayMs = computeBackoffDelayMs(attempt, policy, random);
+      hooks?.onRetry?.({ attempt, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+
+  // Unreachable: loop either returns or throws on the last attempt.
+  throw lastError as Error;
+}

--- a/extension/test/unit/backoff.test.ts
+++ b/extension/test/unit/backoff.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { computeBackoffDelayMs, retryWithBackoff } from '../../src/utils/backoff';
+
+const NO_JITTER = { jitter: 0 } as const;
+
+describe('computeBackoffDelayMs', () => {
+  it('returns capped exponential delays without jitter', () => {
+    const policy = { maxRetries: 5, initialMs: 1000, maxMs: 8000, multiplier: 2, ...NO_JITTER };
+    expect(computeBackoffDelayMs(0, policy)).toBe(1000);
+    expect(computeBackoffDelayMs(1, policy)).toBe(2000);
+    expect(computeBackoffDelayMs(2, policy)).toBe(4000);
+    expect(computeBackoffDelayMs(3, policy)).toBe(8000);
+    expect(computeBackoffDelayMs(4, policy)).toBe(8000); // capped
+    expect(computeBackoffDelayMs(20, policy)).toBe(8000); // still capped
+  });
+
+  it('applies symmetric jitter when configured', () => {
+    const policy = { maxRetries: 3, initialMs: 1000, maxMs: 30000, multiplier: 2, jitter: 0.5 };
+    // random()=0 → -50%; random()=0.5 → 0; random()=1 → +50%
+    expect(computeBackoffDelayMs(0, policy, () => 0)).toBe(500);
+    expect(computeBackoffDelayMs(0, policy, () => 0.5)).toBe(1000);
+    expect(computeBackoffDelayMs(0, policy, () => 1)).toBe(1500);
+  });
+
+  it('clamps to non-negative for any random value', () => {
+    const policy = { maxRetries: 3, initialMs: 100, maxMs: 1000, multiplier: 2, jitter: 5 };
+    expect(computeBackoffDelayMs(0, policy, () => 0)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('retryWithBackoff', () => {
+  const policy = { maxRetries: 3, initialMs: 10, maxMs: 100, multiplier: 2, ...NO_JITTER };
+  let sleep: ReturnType<typeof vi.fn>;
+  const random = () => 0.5;
+
+  beforeEach(() => {
+    sleep = vi.fn(async () => {});
+  });
+
+  it('returns the value on first success without sleeping', async () => {
+    const fn = vi.fn(async () => 'ok');
+    const result = await retryWithBackoff(fn, policy, { sleep, random });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries until success, sleeping with backoff between attempts', async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('transient');
+      return 'eventual';
+    });
+    const onRetry = vi.fn();
+    const result = await retryWithBackoff(fn, policy, { sleep, random, onRetry });
+    expect(result).toBe('eventual');
+    expect(fn).toHaveBeenCalledTimes(3);
+    // 2 sleeps before the third (successful) attempt
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls[0]?.[0]).toBe(10); // attempt 0 -> 10ms
+    expect(sleep.mock.calls[1]?.[0]).toBe(20); // attempt 1 -> 20ms
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry.mock.calls[0]?.[0]).toMatchObject({ attempt: 0, delayMs: 10 });
+  });
+
+  it('throws the last error after exhausting retries', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('always fails');
+    });
+    await expect(retryWithBackoff(fn, policy, { sleep, random })).rejects.toThrow('always fails');
+    // maxRetries=3 -> 4 total attempts
+    expect(fn).toHaveBeenCalledTimes(4);
+    // 3 sleeps between 4 attempts
+    expect(sleep).toHaveBeenCalledTimes(3);
+  });
+
+  it('honors shouldRetry to bail early on non-retryable errors', async () => {
+    const fn = vi.fn(async () => {
+      throw new Error('fatal: 401 Unauthorized');
+    });
+    await expect(
+      retryWithBackoff(fn, policy, {
+        sleep,
+        random,
+        shouldRetry: (err) => !/401/.test(String(err))
+      })
+    ).rejects.toThrow('fatal');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Connect command now retries with exponential backoff on transient failures (network errors, timeouts, 5xx). 4xx auth errors short-circuit immediately. A status-bar countdown shows the active retry.

- \`utils/backoff.ts\`: pure \`computeBackoffDelayMs()\` + \`retryWithBackoff()\` with injection points for sleep/random/shouldRetry/onRetry
- New settings: \`filemaker.connect.maxRetries\` (default 3), \`backoffInitialMs\` (1000), \`backoffMaxMs\` (30000), \`backoffMultiplier\` (2)
- Status bar: \`\$(sync~spin) FileMaker: Connecting to <profile> — retry N/M in Ks\`
- \`isRetryableConnectError()\` classifies ECONNRESET/ECONNREFUSED/ETIMEDOUT/EAI_AGAIN/5xx as retryable

## Test plan
- [x] 7 unit tests: success-first-try, success-after-N-retries (verifies 10ms→20ms backoff sequence), all-retries-exhausted, shouldRetry short-circuit, plus computeBackoffDelayMs cases for capping + jitter
- [x] CI build-test

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)