### PR TITLE
DX: Structured error report with request chain + bug-report copy (#42)

### DIFF
--- a/extension/src/types/errors.ts
+++ b/extension/src/types/errors.ts
@@ -7,6 +7,16 @@ export type NormalizedErrorKind =
   | 'cancellation'
   | 'unknown';
 
+export interface RequestChainEntry {
+  attempt: number;
+  method?: string;
+  url?: string;
+  status?: number;
+  elapsedMs?: number;
+  at?: string;
+  note?: string;
+}
+
 export interface NormalizedError {
   kind: NormalizedErrorKind;
   message: string;
@@ -18,6 +28,14 @@ export interface NormalizedError {
   details?: unknown;
   isRetryable: boolean;
   originalName?: string;
+  /** Number of retry attempts that preceded the final failure. Optional. */
+  retryCount?: number;
+  /** 0-indexed final attempt that produced this error. Optional. */
+  finalAttemptIndex?: number;
+  /** Chronological list of attempts (URL/method/status/elapsed) for the failed operation. */
+  requestChain?: RequestChainEntry[];
+  /** Redacted stack trace, if available. */
+  stackTrace?: string;
 }
 
 export interface NormalizeErrorOptions {

--- a/extension/src/utils/errorUx.ts
+++ b/extension/src/utils/errorUx.ts
@@ -147,15 +147,20 @@ export function renderErrorReport(normalized: NormalizedError, raw?: unknown): s
   return lines.join('\n');
 }
 
+function escapeMarkdownTableCell(value: string): string {
+  // Escape backslashes first so \\ stays \\ and stand-alone | becomes \|.
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
 function formatChainRow(entry: RequestChainEntry): string {
   const cells = [
     String(entry.attempt),
-    entry.method ?? '',
-    entry.url ?? '',
+    escapeMarkdownTableCell(entry.method ?? ''),
+    escapeMarkdownTableCell(entry.url ?? ''),
     entry.status !== undefined ? String(entry.status) : '',
     entry.elapsedMs !== undefined ? `${entry.elapsedMs}ms` : '',
-    entry.at ?? '',
-    (entry.note ?? '').replace(/\|/g, '\\|')
+    escapeMarkdownTableCell(entry.at ?? ''),
+    escapeMarkdownTableCell(entry.note ?? '')
   ];
   return `| ${cells.join(' | ')} |`;
 }

--- a/extension/src/utils/errorUx.ts
+++ b/extension/src/utils/errorUx.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
 
+import type { NormalizedError, RequestChainEntry } from '../types/errors';
 import { normalizeError } from './normalizeError';
-import { redactValue } from './redact';
+import { redactString, redactValue } from './redact';
 
 interface ShowErrorOptions {
   fallbackMessage?: string;
@@ -12,6 +13,9 @@ interface ShowErrorOptions {
 }
 
 const DETAILS_ACTION = 'Details…';
+const COPY_REPORT_ACTION = 'Copy as Bug Report';
+
+let lastRenderedReport: string | undefined;
 
 export async function showErrorWithDetails(
   error: unknown,
@@ -25,28 +29,28 @@ export async function showErrorWithDetails(
     error: normalized
   });
 
-  const selection = await vscode.window.showErrorMessage(normalized.message, DETAILS_ACTION);
+  const report = renderErrorReport(normalized, error);
+  lastRenderedReport = report;
+
+  const selection = await vscode.window.showErrorMessage(
+    normalized.message,
+    DETAILS_ACTION,
+    COPY_REPORT_ACTION
+  );
+
+  if (selection === COPY_REPORT_ACTION) {
+    await vscode.env.clipboard.writeText(report);
+    void vscode.window.showInformationMessage('FileMaker error report copied to clipboard.');
+    return;
+  }
+
   if (selection !== DETAILS_ACTION) {
     return;
   }
 
   const document = await vscode.workspace.openTextDocument({
-    language: 'json',
-    content: JSON.stringify(
-      redactValue({
-        message: normalized.message,
-        kind: normalized.kind,
-        requestId: normalized.requestId,
-        endpoint: normalized.endpoint,
-        status: normalized.status,
-        code: normalized.code,
-        isRetryable: normalized.isRetryable,
-        safeHeaders: normalized.safeHeaders,
-        details: normalized.details
-      }),
-      null,
-      2
-    )
+    language: 'markdown',
+    content: report
   });
 
   await vscode.window.showTextDocument(document, { preview: false });
@@ -56,4 +60,111 @@ export const showCommandError = showErrorWithDetails;
 
 export function toUserErrorMessage(error: unknown, fallbackMessage = 'Unexpected error.'): string {
   return normalizeError(error, { fallbackMessage }).message;
+}
+
+export function getLastErrorReport(): string | undefined {
+  return lastRenderedReport;
+}
+
+/**
+ * Pure rendering of a NormalizedError + raw error into a human-readable
+ * markdown report suitable for both the Details document and the
+ * "Copy as Bug Report" clipboard action.
+ *
+ * Exported for testing.
+ */
+export function renderErrorReport(normalized: NormalizedError, raw?: unknown): string {
+  const lines: string[] = [];
+  lines.push('# FileMaker Data API — Error Report');
+  lines.push('');
+  lines.push(`- **Message:** ${normalized.message}`);
+  lines.push(`- **Kind:** ${normalized.kind}`);
+  if (normalized.status !== undefined) {
+    lines.push(`- **HTTP status:** ${normalized.status}`);
+  }
+  if (normalized.code) {
+    lines.push(`- **Code:** ${normalized.code}`);
+  }
+  if (normalized.endpoint) {
+    lines.push(`- **Endpoint:** ${normalized.endpoint}`);
+  }
+  if (normalized.requestId) {
+    lines.push(`- **Request id:** ${normalized.requestId}`);
+  }
+  lines.push(`- **Retryable:** ${normalized.isRetryable}`);
+  if (typeof normalized.retryCount === 'number') {
+    lines.push(`- **Retry count:** ${normalized.retryCount}`);
+  }
+  if (typeof normalized.finalAttemptIndex === 'number') {
+    lines.push(`- **Final attempt index:** ${normalized.finalAttemptIndex}`);
+  }
+  lines.push('');
+
+  if (normalized.requestChain && normalized.requestChain.length > 0) {
+    lines.push('## Request chain');
+    lines.push('');
+    lines.push('| # | Method | URL | Status | Elapsed | When | Note |');
+    lines.push('|---|---|---|---|---|---|---|');
+    for (const entry of normalized.requestChain) {
+      lines.push(formatChainRow(entry));
+    }
+    lines.push('');
+  }
+
+  if (normalized.safeHeaders && Object.keys(normalized.safeHeaders).length > 0) {
+    lines.push('## Response headers (redacted)');
+    lines.push('');
+    lines.push('```');
+    for (const [key, value] of Object.entries(normalized.safeHeaders)) {
+      lines.push(`${key}: ${value}`);
+    }
+    lines.push('```');
+    lines.push('');
+  }
+
+  if (normalized.details !== undefined) {
+    lines.push('## Details (redacted)');
+    lines.push('');
+    lines.push('```json');
+    lines.push(JSON.stringify(redactValue(normalized.details), null, 2));
+    lines.push('```');
+    lines.push('');
+  }
+
+  const stack = normalized.stackTrace ?? extractStack(raw);
+  if (stack) {
+    lines.push('## Stack trace (redacted)');
+    lines.push('');
+    lines.push('```');
+    lines.push(redactString(stack));
+    lines.push('```');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push(`_Generated at ${new Date().toISOString()}_`);
+  return lines.join('\n');
+}
+
+function formatChainRow(entry: RequestChainEntry): string {
+  const cells = [
+    String(entry.attempt),
+    entry.method ?? '',
+    entry.url ?? '',
+    entry.status !== undefined ? String(entry.status) : '',
+    entry.elapsedMs !== undefined ? `${entry.elapsedMs}ms` : '',
+    entry.at ?? '',
+    (entry.note ?? '').replace(/\|/g, '\\|')
+  ];
+  return `| ${cells.join(' | ')} |`;
+}
+
+function extractStack(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const candidate = (raw as { stack?: unknown }).stack;
+  if (typeof candidate === 'string' && candidate.length > 0) {
+    return candidate;
+  }
+  return undefined;
 }

--- a/extension/test/unit/errorReport.test.ts
+++ b/extension/test/unit/errorReport.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NormalizedError } from '../../src/types/errors';
+import { renderErrorReport } from '../../src/utils/errorUx';
+
+function baseError(): NormalizedError {
+  return {
+    kind: 'server',
+    message: 'Failed to list layouts.',
+    isRetryable: false
+  };
+}
+
+describe('renderErrorReport (#42)', () => {
+  it('renders message, kind, retryable for a minimal error', () => {
+    const out = renderErrorReport(baseError());
+    expect(out).toContain('# FileMaker Data API — Error Report');
+    expect(out).toContain('**Message:** Failed to list layouts.');
+    expect(out).toContain('**Kind:** server');
+    expect(out).toContain('**Retryable:** false');
+  });
+
+  it('includes retry count and final attempt index when present', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      retryCount: 3,
+      finalAttemptIndex: 3
+    });
+    expect(out).toContain('**Retry count:** 3');
+    expect(out).toContain('**Final attempt index:** 3');
+  });
+
+  it('renders the request chain as a markdown table', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      requestChain: [
+        {
+          attempt: 0,
+          method: 'POST',
+          url: 'https://fm.example.com/fmi/data/vLatest/sessions',
+          status: 500,
+          elapsedMs: 412,
+          at: '2026-05-04T16:30:00Z',
+          note: 'transient'
+        },
+        {
+          attempt: 1,
+          method: 'POST',
+          url: 'https://fm.example.com/fmi/data/vLatest/sessions',
+          status: 500,
+          elapsedMs: 401,
+          at: '2026-05-04T16:30:01Z'
+        }
+      ]
+    });
+    expect(out).toContain('## Request chain');
+    expect(out).toContain('| # | Method | URL | Status | Elapsed | When | Note |');
+    expect(out).toMatch(/\|\s*0\s*\|\s*POST\s*\|.*sessions\s*\|\s*500\s*\|\s*412ms\s*\|/);
+    expect(out).toContain('| 1 | POST |');
+  });
+
+  it('redacts authorization headers but keeps non-sensitive ones', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      safeHeaders: {
+        'Content-Type': 'application/json',
+        Authorization: '[redacted]'
+      }
+    });
+    expect(out).toContain('## Response headers (redacted)');
+    expect(out).toContain('Content-Type: application/json');
+    expect(out).toContain('Authorization: [redacted]');
+  });
+
+  it('extracts and redacts stack from raw error when normalized has none', () => {
+    const raw = new Error('boom');
+    raw.stack = 'Error: boom\n    at Authorization=Bearer secrettoken\n    at z()';
+    const out = renderErrorReport(baseError(), raw);
+    expect(out).toContain('## Stack trace (redacted)');
+    expect(out).not.toContain('secrettoken');
+  });
+
+  it('includes details JSON when present', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      details: { code: '102', message: 'Not found' }
+    });
+    expect(out).toContain('## Details (redacted)');
+    expect(out).toContain('"code": "102"');
+  });
+
+  it('omits sections that are empty', () => {
+    const out = renderErrorReport(baseError());
+    expect(out).not.toContain('## Request chain');
+    expect(out).not.toContain('## Response headers');
+    expect(out).not.toContain('## Stack trace');
+  });
+});

--- a/extension/test/unit/errorUx.test.ts
+++ b/extension/test/unit/errorUx.test.ts
@@ -13,7 +13,8 @@ describe('showErrorWithDetails', () => {
 
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
       'Something broke',
-      'Details…'
+      'Details…',
+      'Copy as Bug Report'
     );
   });
 
@@ -24,7 +25,8 @@ describe('showErrorWithDetails', () => {
 
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
       expect.any(String),
-      'Details…'
+      'Details…',
+      'Copy as Bug Report'
     );
   });
 
@@ -39,14 +41,14 @@ describe('showErrorWithDetails', () => {
     expect(logger.error).toHaveBeenCalledWith('Custom log', expect.any(Object));
   });
 
-  it('opens JSON document when Details action is selected', async () => {
+  it('opens markdown document when Details action is selected', async () => {
     vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Details…' as never);
 
     await showErrorWithDetails(new Error('fail'));
 
     expect(vscode.workspace.openTextDocument).toHaveBeenCalledWith(
       expect.objectContaining({
-        language: 'json',
+        language: 'markdown',
         content: expect.any(String)
       })
     );


### PR DESCRIPTION
## Summary
Replaces the JSON Details document with a redacted markdown report and adds a 'Copy as Bug Report' button on every error toast.

The report includes:
- Retry count + final attempt index (when available upstream)
- Request chain (markdown table: method, URL, status, elapsed, when, note)
- Redacted response headers
- Redacted stack trace (extracted from raw \`Error.stack\` when not already surfaced)
- Generated-at timestamp footer

\`NormalizedError\` gains optional \`retryCount\`, \`finalAttemptIndex\`, \`requestChain\`, \`stackTrace\` fields. Existing producers keep current behavior; populating the chain in FMClient is a follow-up so this PR stays small.

## Test plan
- [x] 7 unit tests for \`renderErrorReport\` (minimal error, retry counts, request chain, header redaction, stack redaction, details JSON, empty-section omission)
- [x] CI build-test

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)