### PR TITLE
DX: Inline Test Connection result + save guard in connection wizard (#44)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -706,6 +706,16 @@
           "maximum": 10,
           "description": "Exponential multiplier applied to the connect backoff delay between retries."
         },
+        "filemaker.connectionWizard.requireTestBeforeSave": {
+          "type": "string",
+          "enum": [
+            "off",
+            "warn",
+            "block"
+          ],
+          "default": "warn",
+          "description": "Whether the connection wizard requires a successful Test Connection before Save. 'off' = no requirement; 'warn' = save with confirmation when untested or edits since last test; 'block' = save disabled until a successful test on the current values."
+        },
         "filemaker.secrets.fallback": {
           "type": "string",
           "enum": [

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -37,6 +37,7 @@ interface RegisterCoreCommandDeps {
   onProfileDisconnected?: (profileId: string) => void;
   /** Resolved at call time so settings updates are picked up live. */
   getConnectBackoffPolicy?: () => BackoffPolicy;
+  getConnectionWizardTestPolicy?: () => 'off' | 'warn' | 'block';
 }
 
 function isRetryableConnectError(error: unknown): boolean {
@@ -85,7 +86,9 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
         return;
       }
 
-      ConnectionWizardPanel.createOrShow(context, profileStore, secretStore, fmClient, logger);
+      ConnectionWizardPanel.createOrShow(context, profileStore, secretStore, fmClient, logger, undefined, {
+        getTestPolicy: deps.getConnectionWizardTestPolicy
+      });
     }),
 
     vscode.commands.registerCommand('filemakerDataApiTools.editConnectionProfile', async (arg: unknown) => {
@@ -101,7 +104,9 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
         return;
       }
 
-      ConnectionWizardPanel.createOrShow(context, profileStore, secretStore, fmClient, logger, profile);
+      ConnectionWizardPanel.createOrShow(context, profileStore, secretStore, fmClient, logger, profile, {
+        getTestPolicy: deps.getConnectionWizardTestPolicy
+      });
     }),
 
     vscode.commands.registerCommand(

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -161,7 +161,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     onProfileDisconnected: (profileId) => {
       schemaService.invalidateProfile(profileId);
     },
-    getConnectBackoffPolicy: () => settingsService.getConnectBackoffPolicy()
+    getConnectBackoffPolicy: () => settingsService.getConnectBackoffPolicy(),
+    getConnectionWizardTestPolicy: () => settingsService.getConnectionWizardTestPolicy()
   });
 
   const savedQueryDisposables = registerSavedQueriesCommands({

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -215,6 +215,17 @@ export class SettingsService {
     };
   }
 
+  public getConnectionWizardTestPolicy(): 'off' | 'warn' | 'block' {
+    const configured = this.getConfiguration('filemaker').get<string>(
+      'connectionWizard.requireTestBeforeSave',
+      'warn'
+    );
+    if (configured === 'off' || configured === 'block') {
+      return configured;
+    }
+    return 'warn';
+  }
+
   public getSecretsFallbackMode(): SecretFallbackMode {
     const configured = this.getConfiguration('filemaker').get<string>(
       'secrets.fallback',

--- a/extension/src/webviews/connectionWizard/index.ts
+++ b/extension/src/webviews/connectionWizard/index.ts
@@ -13,6 +13,13 @@ import {
 } from '../../utils/jsonValidate';
 import { toUserErrorMessage } from '../../utils/errorUx';
 
+export type ConnectionWizardTestPolicy = 'off' | 'warn' | 'block';
+
+interface ConnectionWizardOptions {
+  /** Resolved at message time so settings updates flow live. */
+  getTestPolicy?: () => ConnectionWizardTestPolicy;
+}
+
 interface WizardFormData {
   name: string;
   authMode: 'direct' | 'proxy';
@@ -43,7 +50,8 @@ export class ConnectionWizardPanel {
     private readonly secretStore: SecretStore,
     private readonly fmClient: FMClient,
     private readonly logger: Logger,
-    editingProfile?: ConnectionProfile
+    editingProfile?: ConnectionProfile,
+    private readonly options: ConnectionWizardOptions = {}
   ) {
     this.editingProfile = editingProfile;
     this.panel.webview.html = this.getHtmlForWebview(this.panel.webview);
@@ -63,7 +71,8 @@ export class ConnectionWizardPanel {
     secretStore: SecretStore,
     fmClient: FMClient,
     logger: Logger,
-    editingProfile?: ConnectionProfile
+    editingProfile?: ConnectionProfile,
+    options: ConnectionWizardOptions = {}
   ): void {
     if (ConnectionWizardPanel.currentPanel) {
       ConnectionWizardPanel.currentPanel.editingProfile = editingProfile;
@@ -92,7 +101,8 @@ export class ConnectionWizardPanel {
       secretStore,
       fmClient,
       logger,
-      editingProfile
+      editingProfile,
+      options
     );
   }
 
@@ -115,6 +125,7 @@ export class ConnectionWizardPanel {
 
     switch (incoming.type) {
       case 'ready':
+        await this.sendInit();
         await this.sendLoadProfile();
         break;
       case 'save':
@@ -124,6 +135,13 @@ export class ConnectionWizardPanel {
         await this.handleTestConnection(incoming.payload);
         break;
     }
+  }
+
+  private async sendInit(): Promise<void> {
+    await this.panel.webview.postMessage({
+      type: 'init',
+      testPolicy: this.options.getTestPolicy?.() ?? 'warn'
+    });
   }
 
   private async sendLoadProfile(): Promise<void> {

--- a/extension/src/webviews/connectionWizard/ui/index.js
+++ b/extension/src/webviews/connectionWizard/ui/index.js
@@ -14,6 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const statusEl = /** @type {HTMLElement} */ (document.getElementById('status'));
 
   let authMode = 'direct';
+  /** @type {'off'|'warn'|'block'} */
+  let testPolicy = 'warn';
+  /** @type {{state:'untested'|'success'|'failure'|'stale', message?:string, hash?:string}} */
+  let testState = { state: 'untested' };
+  let pendingConfirmedSave = false;
 
   // Mode toggle
   directBtn.addEventListener('click', () => {
@@ -22,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     proxyBtn.classList.remove('active');
     directFields.classList.add('visible');
     proxyFields.classList.remove('visible');
+    onFormChanged();
   });
 
   proxyBtn.addEventListener('click', () => {
@@ -30,11 +36,16 @@ document.addEventListener('DOMContentLoaded', () => {
     directBtn.classList.remove('active');
     proxyFields.classList.add('visible');
     directFields.classList.remove('visible');
+    onFormChanged();
   });
 
   // Initialize
   directBtn.classList.add('active');
   directFields.classList.add('visible');
+
+  // Track every input edit
+  form.addEventListener('input', onFormChanged);
+  form.addEventListener('change', onFormChanged);
 
   // Save
   saveBtn.addEventListener('click', () => {
@@ -43,10 +54,26 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const currentHash = hashForm(data);
+    const guard = evaluateSaveGuard(currentHash);
+
+    if (guard === 'block') {
+      showStatus(
+        'error',
+        'Save blocked by policy: please run a successful Test Connection on the current values first.'
+      );
+      return;
+    }
+
+    if (guard === 'warn' && !pendingConfirmedSave) {
+      showConfirmation(currentHash);
+      return;
+    }
+
+    pendingConfirmedSave = false;
     saveBtn.disabled = true;
     saveBtn.textContent = 'Saving...';
     clearStatus();
-
     vscode.postMessage({ type: 'save', payload: data });
   });
 
@@ -72,6 +99,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     switch (message.type) {
+      case 'init':
+        if (message.testPolicy === 'off' || message.testPolicy === 'warn' || message.testPolicy === 'block') {
+          testPolicy = message.testPolicy;
+        }
+        renderTestState();
+        break;
+
       case 'saveSuccess':
         showStatus('success', message.message || 'Profile saved successfully.');
         saveBtn.disabled = false;
@@ -84,17 +118,27 @@ document.addEventListener('DOMContentLoaded', () => {
         saveBtn.textContent = 'Save Profile';
         break;
 
-      case 'testSuccess':
+      case 'testSuccess': {
+        const data = collectFormData();
+        const hash = data ? hashForm(data) : undefined;
+        testState = { state: 'success', message: message.message, hash };
         showStatus('success', message.message || 'Connection successful.');
+        renderTestState();
         testBtn.disabled = false;
         testBtn.textContent = 'Test Connection';
         break;
+      }
 
-      case 'testError':
+      case 'testError': {
+        const data = collectFormData();
+        const hash = data ? hashForm(data) : undefined;
+        testState = { state: 'failure', message: message.message, hash };
         showStatus('error', message.message || 'Connection failed.');
+        renderTestState();
         testBtn.disabled = false;
         testBtn.textContent = 'Test Connection';
         break;
+      }
 
       case 'loadProfile':
         populateForm(message.payload);
@@ -157,15 +201,16 @@ document.addEventListener('DOMContentLoaded', () => {
       directBtn.click();
       setFieldValue('username', profile.username || '');
     }
+    onFormChanged();
   }
 
   function getValue(id) {
-    const el = document.getElementById(id);
+    const el = /** @type {HTMLInputElement|null} */ (document.getElementById(id));
     return el ? el.value.trim() : '';
   }
 
   function setFieldValue(id, value) {
-    const el = document.getElementById(id);
+    const el = /** @type {HTMLInputElement|null} */ (document.getElementById(id));
     if (el) el.value = value;
   }
 
@@ -177,6 +222,99 @@ document.addEventListener('DOMContentLoaded', () => {
   function clearStatus() {
     statusEl.className = 'status';
     statusEl.textContent = '';
+  }
+
+  function onFormChanged() {
+    pendingConfirmedSave = false;
+    if (testState.state === 'success' || testState.state === 'failure') {
+      const data = collectFormData();
+      const newHash = data ? hashForm(data) : undefined;
+      if (newHash !== testState.hash) {
+        testState = { state: 'stale', message: testState.message };
+      }
+    }
+    renderTestState();
+  }
+
+  function renderTestState() {
+    let badge = document.getElementById('testBadge');
+    if (!badge) {
+      badge = document.createElement('div');
+      badge.id = 'testBadge';
+      badge.className = 'test-badge';
+      const buttonsContainer = saveBtn.parentElement;
+      if (buttonsContainer) {
+        buttonsContainer.insertBefore(badge, saveBtn);
+      } else {
+        document.body.appendChild(badge);
+      }
+    }
+
+    let label = '';
+    let cls = 'test-badge';
+    switch (testState.state) {
+      case 'untested':
+        label = testPolicy === 'off' ? '' : '⚪ Connection not tested';
+        cls += ' untested';
+        break;
+      case 'success':
+        label = '🟢 Test passed';
+        cls += ' success';
+        break;
+      case 'failure':
+        label = `🔴 Test failed${testState.message ? ': ' + testState.message : ''}`;
+        cls += ' failure';
+        break;
+      case 'stale':
+        label = '🟡 Edits since last test';
+        cls += ' stale';
+        break;
+    }
+    badge.textContent = label;
+    badge.className = cls;
+    badge.style.display = label ? '' : 'none';
+  }
+
+  /**
+   * @param {string} hash
+   * @returns {'ok'|'warn'|'block'}
+   */
+  function evaluateSaveGuard(hash) {
+    if (testPolicy === 'off') return 'ok';
+    const passed = testState.state === 'success' && testState.hash === hash;
+    if (passed) return 'ok';
+    return testPolicy === 'block' ? 'block' : 'warn';
+  }
+
+  function showConfirmation(hash) {
+    const confirmed = window.confirm(
+      'You have not run a successful Test Connection on the current values. Save anyway?'
+    );
+    if (confirmed) {
+      pendingConfirmedSave = true;
+      saveBtn.click();
+    }
+  }
+
+  /**
+   * @param {Record<string, unknown>} data
+   * @returns {string}
+   */
+  function hashForm(data) {
+    // Stable, order-independent hash. Excludes secrets so the form is considered
+    // "tested" even after the user re-enters a password (tests didn't change auth values
+    // unless the auth fields themselves changed).
+    const subset = {
+      name: data.name,
+      authMode: data.authMode,
+      serverUrl: data.serverUrl,
+      database: data.database,
+      apiBasePath: data.apiBasePath,
+      apiVersionPath: data.apiVersionPath,
+      username: data.username,
+      proxyEndpoint: data.proxyEndpoint
+    };
+    return JSON.stringify(subset);
   }
 
   // Tell the extension we're ready

--- a/extension/src/webviews/connectionWizard/ui/styles.css
+++ b/extension/src/webviews/connectionWizard/ui/styles.css
@@ -239,3 +239,29 @@ h1 {
 }
 
 .loading-skeleton.hidden { display: none; }
+
+.test-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  margin: 0 8px 0 0;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: var(--vscode-font-family);
+  background: var(--vscode-input-background, #2d2d2d);
+  color: var(--vscode-foreground, #d4d4d4);
+  border: 1px solid var(--vscode-input-border, transparent);
+  vertical-align: middle;
+}
+.test-badge.untested { opacity: 0.7; }
+.test-badge.success {
+  background: var(--vscode-testing-iconPassed, #1f6f1f);
+  color: #ffffff;
+}
+.test-badge.failure {
+  background: var(--vscode-testing-iconFailed, #b22222);
+  color: #ffffff;
+}
+.test-badge.stale {
+  background: var(--vscode-editorWarning-foreground, #cc8400);
+  color: #1f1f1f;
+}


### PR DESCRIPTION
## Summary
Wizard now shows a persistent Test Connection badge (untested / 🟢 passed / 🔴 failed / 🟡 stale-after-edits) and applies a save guard based on a new policy setting.

- \`filemaker.connectionWizard.requireTestBeforeSave\`: \`off\` | \`warn\` (default) | \`block\`
- Form changes invalidate a prior Pass via a stable hash of the form (secrets excluded)
- 'warn': Save shows a confirmation when untested or stale; 'block': Save rejected until current values pass

## Test plan
- [x] CI build-test
- [ ] Manual: open wizard, edit fields → badge becomes \`🟡 Edits since last test\`; Test Connection → badge becomes \`🟢 Test passed\`; click Save → no warning. Edit a field → badge stale → Save → confirm prompt.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)