### PR TITLE
DX: Layout field reference panel in Query Builder (#41)

### DIFF
--- a/extension/src/utils/layoutFields.ts
+++ b/extension/src/utils/layoutFields.ts
@@ -1,0 +1,44 @@
+/**
+ * Extract field names from a FileMaker Data API layout metadata payload.
+ *
+ * The Data API returns a metadata document under `response.fieldMetaData`
+ * (regular fields) and `response.portalMetaData[<table>]` (related fields).
+ * Some servers/proxies return the same arrays at the top level. This
+ * helper handles both shapes defensively and is exported for unit tests.
+ */
+export function extractLayoutFieldNames(metadata: unknown): string[] {
+  const seen = new Set<string>();
+
+  if (!metadata || typeof metadata !== 'object') {
+    return [];
+  }
+
+  const root = metadata as Record<string, unknown>;
+  const responseField = root.response;
+  const responseRoot =
+    responseField && typeof responseField === 'object' ? (responseField as Record<string, unknown>) : root;
+
+  collectFromArray(responseRoot.fieldMetaData, seen);
+  collectFromArray(root.fieldMetaData, seen);
+
+  const portalRoot = responseRoot.portalMetaData ?? root.portalMetaData;
+  if (portalRoot && typeof portalRoot === 'object' && !Array.isArray(portalRoot)) {
+    for (const value of Object.values(portalRoot as Record<string, unknown>)) {
+      collectFromArray(value, seen);
+    }
+  }
+
+  return Array.from(seen).sort((a, b) => a.localeCompare(b));
+}
+
+function collectFromArray(value: unknown, sink: Set<string>): void {
+  if (!Array.isArray(value)) return;
+  for (const item of value) {
+    if (item && typeof item === 'object' && 'name' in item) {
+      const name = (item as { name?: unknown }).name;
+      if (typeof name === 'string' && name.length > 0) {
+        sink.add(name);
+      }
+    }
+  }
+}

--- a/extension/src/webviews/queryBuilder/index.ts
+++ b/extension/src/webviews/queryBuilder/index.ts
@@ -8,6 +8,7 @@ import type { ProfileStore } from '../../services/profileStore';
 import type { SavedQueriesStore } from '../../services/savedQueriesStore';
 import type { ConnectionProfile, FindRecordsRequest, SavedQuery } from '../../types/fm';
 import { recordsToCsv } from '../../utils/exportCsv';
+import { extractLayoutFieldNames } from '../../utils/layoutFields';
 import { parseFindJson, parseSortJson } from '../../utils/jsonValidate';
 import { generateCurlSnippet, generateFetchSnippet, type SnippetRequest } from '../../utils/snippetGen';
 import { buildWebviewCsp, createNonce } from '../common/csp';
@@ -55,6 +56,7 @@ interface QueryExecutionResult {
 type IncomingMessage =
   | { type: 'ready' }
   | { type: 'loadLayouts'; profileId: string }
+  | { type: 'loadFieldNames'; profileId: string; layout: string }
   | { type: 'runQuery'; payload: RunQueryPayload }
   | { type: 'saveQuery'; payload: SaveQueryPayload }
   | { type: 'exportResultsToEditor' }
@@ -160,6 +162,9 @@ export class QueryBuilderPanel {
       case 'loadLayouts':
         await this.handleLoadLayouts(message.profileId);
         break;
+      case 'loadFieldNames':
+        await this.handleLoadFieldNames(message.profileId, message.layout);
+        break;
       case 'runQuery':
         await this.handleRunQuery(message.payload);
         break;
@@ -244,6 +249,37 @@ export class QueryBuilderPanel {
     } catch (error) {
       this.logger.error('Failed to load layouts for query builder.', { profileId, error });
       await this.postError(this.formatError(error));
+    }
+  }
+
+  private async handleLoadFieldNames(profileId: string, layout: string): Promise<void> {
+    const profile = await this.profileStore.getProfile(profileId);
+    if (!profile) {
+      await this.panel.webview.postMessage({
+        type: 'fieldNamesLoaded',
+        payload: { profileId, layout, fieldNames: [], error: 'Profile not found.' }
+      });
+      return;
+    }
+
+    try {
+      const metadata = await this.fmClient.getLayoutMetadata(profile, layout);
+      const fieldNames = extractLayoutFieldNames(metadata);
+      await this.panel.webview.postMessage({
+        type: 'fieldNamesLoaded',
+        payload: { profileId, layout, fieldNames }
+      });
+    } catch (error) {
+      this.logger.warn('Failed to load field names for query builder.', { profileId, layout, error });
+      await this.panel.webview.postMessage({
+        type: 'fieldNamesLoaded',
+        payload: {
+          profileId,
+          layout,
+          fieldNames: [],
+          error: this.formatError(error)
+        }
+      });
     }
   }
 
@@ -564,6 +600,14 @@ export class QueryBuilderPanel {
           type,
           profileId
         };
+      }
+      case 'loadFieldNames': {
+        const profileId = getStringField(value, 'profileId');
+        const layout = getStringField(value, 'layout');
+        if (!profileId || !layout) {
+          return undefined;
+        }
+        return { type, profileId, layout };
       }
       case 'runQuery': {
         const payload = this.parseRunQueryPayload(value.payload);

--- a/extension/src/webviews/queryBuilder/ui/index.js
+++ b/extension/src/webviews/queryBuilder/ui/index.js
@@ -67,6 +67,10 @@ window.addEventListener('message', (event) => {
       break;
     case 'layoutsLoaded':
       applyLayouts(message.payload);
+      requestFieldNamesForCurrentLayout();
+      break;
+    case 'fieldNamesLoaded':
+      renderFieldNames(message.payload);
       break;
     case 'queryResult':
       renderQueryResult(message.payload);
@@ -95,6 +99,12 @@ profileSelect.addEventListener('change', () => {
   const profileId = profileSelect.value;
   requestLayouts(profileId);
 });
+
+if (layoutSelect) {
+  layoutSelect.addEventListener('change', () => {
+    requestFieldNamesForCurrentLayout();
+  });
+}
 
 runButton.addEventListener('click', () => {
   const payload = collectPayload();
@@ -780,6 +790,80 @@ function renderVirtualizedTable(records, columns) {
 function setStatus(message, isError = false) {
   status.textContent = message;
   status.classList.toggle('error', isError);
+}
+
+function requestFieldNamesForCurrentLayout() {
+  const profileId = profileSelect ? profileSelect.value : '';
+  const layout = layoutSelect ? layoutSelect.value : '';
+  if (!profileId || !layout) {
+    renderFieldNames({ profileId: '', layout: '', fieldNames: [] });
+    return;
+  }
+  vscode.postMessage({ type: 'loadFieldNames', profileId, layout });
+}
+
+function renderFieldNames(payload) {
+  let panel = document.getElementById('fieldNamesPanel');
+  if (!panel) {
+    const findContainer = findJson ? findJson.parentElement : null;
+    if (!findContainer) return;
+    panel = document.createElement('div');
+    panel.id = 'fieldNamesPanel';
+    panel.className = 'field-names-panel';
+    findContainer.insertBefore(panel, findJson);
+  }
+
+  const names = Array.isArray(payload && payload.fieldNames) ? payload.fieldNames : [];
+  const error = payload && payload.error;
+  panel.innerHTML = '';
+
+  if (error) {
+    const msg = document.createElement('div');
+    msg.className = 'field-names-error';
+    msg.textContent = `Layout fields unavailable: ${error}`;
+    panel.appendChild(msg);
+    return;
+  }
+
+  if (names.length === 0) {
+    panel.style.display = 'none';
+    return;
+  }
+
+  panel.style.display = '';
+
+  const header = document.createElement('div');
+  header.className = 'field-names-header';
+  header.textContent = `Layout fields (${names.length}) — click to insert`;
+  panel.appendChild(header);
+
+  const chipRow = document.createElement('div');
+  chipRow.className = 'field-names-chips';
+  for (const name of names) {
+    const chip = document.createElement('button');
+    chip.type = 'button';
+    chip.className = 'field-name-chip';
+    chip.textContent = name;
+    chip.title = `Insert "${name}" into the find JSON`;
+    chip.addEventListener('click', () => insertFieldNameIntoFindJson(name));
+    chipRow.appendChild(chip);
+  }
+  panel.appendChild(chipRow);
+}
+
+function insertFieldNameIntoFindJson(fieldName) {
+  if (!findJson) return;
+  const insertion = `"${fieldName}": ""`;
+  const start = findJson.selectionStart ?? findJson.value.length;
+  const end = findJson.selectionEnd ?? findJson.value.length;
+  const before = findJson.value.slice(0, start);
+  const after = findJson.value.slice(end);
+  const needsComma = /[}\]"]\s*$/.test(before.trim());
+  const prefix = needsComma ? ', ' : '';
+  findJson.value = `${before}${prefix}${insertion}${after}`;
+  const cursor = (before + prefix + insertion).length - 1; // place caret between the empty quotes
+  findJson.focus();
+  findJson.setSelectionRange(cursor, cursor);
 }
 
 vscode.postMessage({ type: 'ready' });

--- a/extension/src/webviews/queryBuilder/ui/styles.css
+++ b/extension/src/webviews/queryBuilder/ui/styles.css
@@ -234,3 +234,43 @@ th {
     flex: 1;
   }
 }
+
+.field-names-panel {
+  margin: 8px 0;
+  padding: 8px 10px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  background: rgba(15, 118, 110, 0.04);
+  font-size: 0.85em;
+}
+.field-names-header {
+  color: var(--muted);
+  font-size: 0.78em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+.field-names-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.field-name-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--text);
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 0.78em;
+  cursor: pointer;
+}
+.field-name-chip:hover {
+  border-color: var(--accent);
+  background: rgba(15, 118, 110, 0.08);
+}
+.field-names-error {
+  color: var(--error);
+  font-size: 0.8em;
+}

--- a/extension/test/unit/utils/layoutFields.test.ts
+++ b/extension/test/unit/utils/layoutFields.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractLayoutFieldNames } from '../../../src/utils/layoutFields';
+
+describe('extractLayoutFieldNames', () => {
+  it('returns [] for non-objects', () => {
+    expect(extractLayoutFieldNames(null)).toEqual([]);
+    expect(extractLayoutFieldNames(undefined)).toEqual([]);
+    expect(extractLayoutFieldNames('x')).toEqual([]);
+    expect(extractLayoutFieldNames(42)).toEqual([]);
+    expect(extractLayoutFieldNames([])).toEqual([]);
+  });
+
+  it('reads regular fields under response.fieldMetaData', () => {
+    const metadata = {
+      response: {
+        fieldMetaData: [
+          { name: 'firstName', type: 'text' },
+          { name: 'lastName', type: 'text' },
+          { name: 'age', type: 'number' }
+        ]
+      }
+    };
+    expect(extractLayoutFieldNames(metadata)).toEqual(['age', 'firstName', 'lastName']);
+  });
+
+  it('reads top-level fieldMetaData when response wrapper is absent', () => {
+    expect(
+      extractLayoutFieldNames({
+        fieldMetaData: [{ name: 'A' }, { name: 'B' }]
+      })
+    ).toEqual(['A', 'B']);
+  });
+
+  it('walks portalMetaData related-table fields', () => {
+    const metadata = {
+      response: {
+        fieldMetaData: [{ name: 'orderId' }],
+        portalMetaData: {
+          LineItems: [{ name: 'sku' }, { name: 'qty' }],
+          Payments: [{ name: 'amount' }]
+        }
+      }
+    };
+    expect(extractLayoutFieldNames(metadata)).toEqual([
+      'amount',
+      'orderId',
+      'qty',
+      'sku'
+    ]);
+  });
+
+  it('deduplicates names appearing in both regular and portal arrays', () => {
+    const metadata = {
+      response: {
+        fieldMetaData: [{ name: 'shared' }],
+        portalMetaData: {
+          rel: [{ name: 'shared' }, { name: 'unique' }]
+        }
+      }
+    };
+    expect(extractLayoutFieldNames(metadata)).toEqual(['shared', 'unique']);
+  });
+
+  it('ignores items without a string name', () => {
+    expect(
+      extractLayoutFieldNames({
+        fieldMetaData: [{ name: 'good' }, { type: 'text' }, { name: 42 }, { name: '' }]
+      })
+    ).toEqual(['good']);
+  });
+});


### PR DESCRIPTION
## Summary
Surfaces the active layout's field names in the Query Builder. Selecting a layout fetches metadata via \`fmClient.getLayoutMetadata\`, extracts field names with a new \`extractLayoutFieldNames\` utility, and renders them as clickable chips above the find JSON editor. Click → inserts \`\"FIELD_NAME\": \"\"\` at the caret with a comma if needed.

\`extractLayoutFieldNames\` handles both standard (\`response.fieldMetaData\`/\`response.portalMetaData\`) and proxy-flat shapes.

## Deferred
Full inline-IntelliSense (cursor-aware path filtering, keyboard nav) is a follow-up. This PR ships the metadata pipeline end-to-end so the editor plumbing can be added later without re-architecting the data flow.

## Test plan
- [x] 6 unit tests for \`extractLayoutFieldNames\` (non-object, regular fields, portal fields, dedup, missing names, proxy shape)
- [x] CI build-test
- [ ] Manual: open Query Builder, pick a profile + layout → see chip panel with sorted field names; click a chip → JSON gains \`\"name\": \"\"\` at caret.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)