### PR TITLE
fix(errorUx): redact summary fields + defer render (follow-up to #59)

### DIFF
--- a/extension/src/utils/errorUx.ts
+++ b/extension/src/utils/errorUx.ts
@@ -29,22 +29,33 @@ export async function showErrorWithDetails(
     error: normalized
   });
 
-  const report = renderErrorReport(normalized, error);
-  lastRenderedReport = report;
-
   const selection = await vscode.window.showErrorMessage(
     normalized.message,
     DETAILS_ACTION,
     COPY_REPORT_ACTION
   );
 
-  if (selection === COPY_REPORT_ACTION) {
-    await vscode.env.clipboard.writeText(report);
-    void vscode.window.showInformationMessage('FileMaker error report copied to clipboard.');
+  if (selection !== COPY_REPORT_ACTION && selection !== DETAILS_ACTION) {
+    // Toast dismissed — skip the (potentially expensive) report rendering entirely.
     return;
   }
 
-  if (selection !== DETAILS_ACTION) {
+  // Defer rendering until an action is selected. Building the report eagerly
+  // adds extension-host overhead for every error and can throw on non-serializable
+  // detail values, suppressing the original toast.
+  let report: string;
+  try {
+    report = renderErrorReport(normalized, error);
+  } catch (renderError) {
+    options?.logger?.error('Failed to render error report.', { renderError });
+    void vscode.window.showErrorMessage('Failed to generate FileMaker error report.');
+    return;
+  }
+  lastRenderedReport = report;
+
+  if (selection === COPY_REPORT_ACTION) {
+    await vscode.env.clipboard.writeText(report);
+    void vscode.window.showInformationMessage('FileMaker error report copied to clipboard.');
     return;
   }
 
@@ -66,18 +77,31 @@ export function getLastErrorReport(): string | undefined {
   return lastRenderedReport;
 }
 
+interface RenderErrorReportOptions {
+  /** Override the generated-at timestamp. Useful for deterministic tests. */
+  generatedAt?: Date;
+}
+
 /**
- * Pure rendering of a NormalizedError + raw error into a human-readable
+ * Renders a NormalizedError + raw error into a redacted, human-readable
  * markdown report suitable for both the Details document and the
  * "Copy as Bug Report" clipboard action.
  *
+ * All free-form string fields (message, endpoint, requestId, request-chain
+ * URLs/notes) are passed through `redactString` so secrets embedded in
+ * messages or query params are masked before they reach the clipboard.
+ *
  * Exported for testing.
  */
-export function renderErrorReport(normalized: NormalizedError, raw?: unknown): string {
+export function renderErrorReport(
+  normalized: NormalizedError,
+  raw?: unknown,
+  options: RenderErrorReportOptions = {}
+): string {
   const lines: string[] = [];
   lines.push('# FileMaker Data API — Error Report');
   lines.push('');
-  lines.push(`- **Message:** ${normalized.message}`);
+  lines.push(`- **Message:** ${redactString(normalized.message)}`);
   lines.push(`- **Kind:** ${normalized.kind}`);
   if (normalized.status !== undefined) {
     lines.push(`- **HTTP status:** ${normalized.status}`);
@@ -86,10 +110,10 @@ export function renderErrorReport(normalized: NormalizedError, raw?: unknown): s
     lines.push(`- **Code:** ${normalized.code}`);
   }
   if (normalized.endpoint) {
-    lines.push(`- **Endpoint:** ${normalized.endpoint}`);
+    lines.push(`- **Endpoint:** ${redactString(normalized.endpoint)}`);
   }
   if (normalized.requestId) {
-    lines.push(`- **Request id:** ${normalized.requestId}`);
+    lines.push(`- **Request id:** ${redactString(normalized.requestId)}`);
   }
   lines.push(`- **Retryable:** ${normalized.isRetryable}`);
   if (typeof normalized.retryCount === 'number') {
@@ -143,7 +167,8 @@ export function renderErrorReport(normalized: NormalizedError, raw?: unknown): s
 
   lines.push('---');
   lines.push('');
-  lines.push(`_Generated at ${new Date().toISOString()}_`);
+  const generatedAt = options.generatedAt ?? new Date();
+  lines.push(`_Generated at ${generatedAt.toISOString()}_`);
   return lines.join('\n');
 }
 
@@ -152,15 +177,21 @@ function escapeMarkdownTableCell(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
+function redactAndEscapeCell(value: string | undefined): string {
+  if (!value) return '';
+  // Redact first (so the redacted form passes through escape), then escape table-breaking chars.
+  return escapeMarkdownTableCell(redactString(value));
+}
+
 function formatChainRow(entry: RequestChainEntry): string {
   const cells = [
     String(entry.attempt),
-    escapeMarkdownTableCell(entry.method ?? ''),
-    escapeMarkdownTableCell(entry.url ?? ''),
+    redactAndEscapeCell(entry.method),
+    redactAndEscapeCell(entry.url),
     entry.status !== undefined ? String(entry.status) : '',
     entry.elapsedMs !== undefined ? `${entry.elapsedMs}ms` : '',
-    escapeMarkdownTableCell(entry.at ?? ''),
-    escapeMarkdownTableCell(entry.note ?? '')
+    redactAndEscapeCell(entry.at),
+    redactAndEscapeCell(entry.note)
   ];
   return `| ${cells.join(' | ')} |`;
 }

--- a/extension/test/unit/errorReport.test.ts
+++ b/extension/test/unit/errorReport.test.ts
@@ -95,4 +95,59 @@ describe('renderErrorReport (#42)', () => {
     expect(out).not.toContain('## Response headers');
     expect(out).not.toContain('## Stack trace');
   });
+
+  it('redacts Bearer tokens in the message summary field', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      message: 'Request failed with header Bearer abc123secret'
+    });
+    expect(out).not.toContain('abc123secret');
+    expect(out).toContain('Bearer ***');
+  });
+
+  it('redacts query-param secrets in endpoint summary field', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      endpoint: 'GET /layouts?token=secrettoken'
+    });
+    expect(out).not.toContain('secrettoken');
+    expect(out).toContain('token=***');
+  });
+
+  it('redacts secrets in request-chain URL cells', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      requestChain: [
+        {
+          attempt: 0,
+          method: 'GET',
+          url: 'https://fm.example.com/api?api_key=verysecretkey',
+          note: 'retried after 401'
+        }
+      ]
+    });
+    expect(out).not.toContain('verysecretkey');
+    expect(out).toContain('api_key=***');
+  });
+
+  it('redacts Bearer tokens in request-chain note cells', () => {
+    const out = renderErrorReport({
+      ...baseError(),
+      requestChain: [
+        {
+          attempt: 0,
+          method: 'GET',
+          url: 'https://fm.example.com/api',
+          note: 'auth header was Bearer leakedtoken'
+        }
+      ]
+    });
+    expect(out).not.toContain('leakedtoken');
+  });
+
+  it('accepts a deterministic generatedAt for stable output', () => {
+    const fixedDate = new Date('2026-01-01T00:00:00.000Z');
+    const out = renderErrorReport(baseError(), undefined, { generatedAt: fixedDate });
+    expect(out).toContain('_Generated at 2026-01-01T00:00:00.000Z_');
+  });
 });

--- a/extension/test/unit/errorUx.test.ts
+++ b/extension/test/unit/errorUx.test.ts
@@ -62,6 +62,35 @@ describe('showErrorWithDetails', () => {
 
     expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
   });
+
+  it('copies report to clipboard when Copy as Bug Report is selected', async () => {
+    vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Copy as Bug Report' as never);
+
+    await showErrorWithDetails(new Error('boom'));
+
+    expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('# FileMaker Data API — Error Report')
+    );
+    // No document is opened on the copy path.
+    expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+  });
+
+  it('does not render the report when toast is dismissed (deferred rendering)', async () => {
+    vi.mocked(vscode.window.showErrorMessage).mockResolvedValue(undefined as never);
+
+    // Pass a non-serializable value via a getter that throws — would crash if rendered eagerly.
+    const evil = new Error('toxic');
+    Object.defineProperty(evil, 'stack', {
+      get() {
+        throw new Error('do not access');
+      }
+    });
+
+    await expect(showErrorWithDetails(evil)).resolves.toBeUndefined();
+    // Clipboard and document remain untouched because we only render on action.
+    expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+    expect(vscode.workspace.openTextDocument).not.toHaveBeenCalled();
+  });
 });
 
 describe('toUserErrorMessage', () => {


### PR DESCRIPTION
## Summary
Follow-up to #59. Addresses unresolved review feedback that was merged before fixes could land.

## Issues addressed

### P1 — Secrets leaked in error reports (Codex, Copilot)

Reviewers flagged that `renderErrorReport` was writing free-form fields verbatim into the markdown report. With the new "Copy as Bug Report" clipboard action, those fields can land in tickets, chat, or pasted summaries.

**Fields that previously leaked:**
- `normalized.message` — known to contain `Bearer ...` fragments via `FMClient.getErrorMessage()`
- `normalized.endpoint` — may include `?token=...` query params
- `normalized.requestId` — free-form string, occasionally embeds session tags
- request-chain rows — `method`, `url`, `at`, `note` cells (URLs frequently carry token query params)

**Fix:** all of those fields now go through `redactString` before being written. Request-chain cells use a single helper (`redactAndEscapeCell`) that redacts then escapes table-breaking characters consistently.

### P2 — Eager rendering before action selected (Codex)

Every `showErrorWithDetails` call was building the full markdown report up front, even when the user dismissed the toast. That added needless overhead and could throw on unusual `details` payloads, which suppressed the original error toast entirely.

**Fix:** report rendering is now deferred until a `Details…` or `Copy as Bug Report` action is actually selected, wrapped in try/catch so a render failure produces a clean fallback toast instead of swallowing the original error.

### Doc accuracy (Copilot)

`renderErrorReport`'s doc comment claimed "Pure rendering" while internally calling `new Date().toISOString()`. The function now accepts an optional `generatedAt` parameter for deterministic tests, and the comment no longer over-promises purity.

## Tests

`errorReport.test.ts`:
- Bearer-token redaction in message
- Query-param redaction in endpoint
- Query-param redaction in request-chain URL cells
- Bearer-token redaction in request-chain note cells
- Deterministic `generatedAt` override

`errorUx.test.ts`:
- Clipboard write on Copy-as-Bug-Report path
- Deferred rendering: a non-serializable error survives toast dismissal without crashing

## Test plan
- [ ] CI build-test passes
- [ ] CodeQL passes (existing backslash-escape fix from #59 already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
