### PR TITLE
UX: Onboarding scaffolding — walkthrough + activity-bar icon + welcome view (#89)

### DIFF
--- a/extension/docs/walkthroughs/add-profile.md
+++ b/extension/docs/walkthroughs/add-profile.md
@@ -1,0 +1,23 @@
+# Step 1 — Add a connection profile
+
+A **connection profile** stores how to reach your FileMaker server and which
+database to talk to. Passwords are stored in your OS keychain via VS Code's
+SecretStorage — they never sit on disk in plain text.
+
+Click the **Add Profile** button or run **FileMaker: Add Connection Profile**
+from the Command Palette (`Ctrl/Cmd+Shift+P`). The connection wizard opens
+in an editor tab. You'll need:
+
+- **Server URL** — e.g. `https://fm.example.com`
+- **Database name** — the name of the file on the server (without `.fmp12`)
+- **Auth mode** — `Direct` for username + password against the Data API, or
+  `Proxy` if your team runs a relay
+- **API base path** and **version** are pre-filled to the FileMaker defaults
+  (`/fmi/data` + `vLatest`) — leave them alone unless your admin says otherwise
+
+Click **Test Connection** before saving. The wizard shows a colored badge
+inline so you know whether the credentials work without leaving the page.
+
+> **Tip:** Profiles are scoped per workspace by default. If you want one
+> profile available everywhere, change `filemaker.savedQueries.scope` after
+> saving.

--- a/extension/docs/walkthroughs/query-builder.md
+++ b/extension/docs/walkthroughs/query-builder.md
@@ -1,0 +1,29 @@
+# Step 3 — Run your first query
+
+With an active connection, you've got two paths:
+
+## Quick: list layouts and pick a record
+
+Run **FileMaker: List Layouts** to see every layout exposed via the Data
+API. Right-click a layout in the sidebar to get common actions:
+**Open Query Builder**, **Get Record by ID**, **Open Layout Metadata**,
+**Generate Types for Layout**, **Batch Export (Find)**.
+
+## Powerful: the Query Builder
+
+Run **FileMaker: Open Query Builder**. The query builder lets you:
+
+- pick a profile + layout from dropdowns
+- enter the find request as JSON (the layout's field names show up as
+  clickable chips above the editor — click to insert)
+- preview results in a table
+- save the query for re-use, with optional **export** to JSON/CSV files
+- copy the equivalent `curl` or `fetch` snippet to share or paste into a
+  bug report
+
+Saved queries are scoped per workspace by default. Use
+**FileMaker: Export Saved Queries (JSON)** if you want to share them with
+your team via Git or a chat tool.
+
+That's it — you're ready to go. The full command list is in the palette
+under the **FileMaker:** prefix.

--- a/extension/docs/walkthroughs/test-connect.md
+++ b/extension/docs/walkthroughs/test-connect.md
@@ -1,0 +1,21 @@
+# Step 2 — Connect
+
+Once you've saved a profile, run **FileMaker: Connect** (or right-click the
+profile in the FileMaker sidebar and choose **Connect**).
+
+Connect will:
+
+1. **Authenticate** — opens a session against the Data API and stores the
+   token in your OS keychain.
+2. **Refresh proactively** — the extension renews the token before its
+   nominal 15-minute expiry, so long-running queries don't get kicked out.
+3. **Retry transient failures** — network blips, 5xx errors, and timeouts
+   are retried with exponential backoff so you don't have to.
+
+You'll see a status-bar item showing connection state. The first time the
+session token times out due to inactivity, the extension reconnects
+automatically.
+
+> **If Connect fails**, the error toast offers **Retry**, **Edit Profile**,
+> and **Show Details**. The Details document is redacted but includes the
+> retry chain and the failing endpoint — useful for filing bug reports.

--- a/extension/media/filemaker.svg
+++ b/extension/media/filemaker.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3.5" y="3.5" width="17" height="17" rx="3" />
+  <line x1="3.5" y1="9" x2="20.5" y2="9" />
+  <line x1="3.5" y1="15" x2="20.5" y2="15" />
+  <line x1="9" y1="3.5" x2="9" y2="20.5" />
+</svg>

--- a/extension/package.json
+++ b/extension/package.json
@@ -39,15 +39,82 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
-    "views": {
-      "explorer": [
+    "viewsContainers": {
+      "activitybar": [
         {
-          "id": "filemakerExplorer",
-          "name": "FileMaker Explorer"
+          "id": "filemakerActivityBar",
+          "title": "FileMaker",
+          "icon": "media/filemaker.svg"
         }
       ]
     },
+    "views": {
+      "filemakerActivityBar": [
+        {
+          "id": "filemakerExplorer",
+          "name": "Connections",
+          "contextualTitle": "FileMaker",
+          "icon": "media/filemaker.svg"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "filemakerExplorer",
+        "contents": "No FileMaker connections yet.\n[Add Connection Profile](command:filemakerDataApiTools.addConnectionProfile)\n[Open Walkthrough](command:filemakerDataApiTools.openWelcomeWalkthrough)\n\nYour passwords stay in the OS keychain. Learn more in the [User Guide](command:filemakerDataApiTools.openUserGuide)."
+      }
+    ],
+    "walkthroughs": [
+      {
+        "id": "filemakerGettingStarted",
+        "title": "Get started with FileMaker Data API Tools",
+        "description": "Set up a connection profile and run your first query in three steps.",
+        "steps": [
+          {
+            "id": "addProfile",
+            "title": "Add a connection profile",
+            "description": "Tell the extension how to reach your FileMaker server. Passwords go to the OS keychain — they never touch your workspace files.\n[Add Profile](command:filemakerDataApiTools.addConnectionProfile)",
+            "media": {
+              "markdown": "docs/walkthroughs/add-profile.md"
+            },
+            "completionEvents": [
+              "onCommand:filemakerDataApiTools.addConnectionProfile"
+            ]
+          },
+          {
+            "id": "connect",
+            "title": "Connect and verify",
+            "description": "Open a session against the Data API. Transient failures retry with exponential backoff and the token refreshes proactively before expiry.\n[Connect](command:filemakerDataApiTools.connect)",
+            "media": {
+              "markdown": "docs/walkthroughs/test-connect.md"
+            },
+            "completionEvents": [
+              "onCommand:filemakerDataApiTools.connect"
+            ]
+          },
+          {
+            "id": "runQuery",
+            "title": "Run your first query",
+            "description": "List layouts, pick one, and open the Query Builder. Field-name chips above the JSON editor save typing.\n[Open Query Builder](command:filemakerDataApiTools.openQueryBuilder)",
+            "media": {
+              "markdown": "docs/walkthroughs/query-builder.md"
+            },
+            "completionEvents": [
+              "onCommand:filemakerDataApiTools.openQueryBuilder"
+            ]
+          }
+        ]
+      }
+    ],
     "commands": [
+      {
+        "command": "filemakerDataApiTools.openWelcomeWalkthrough",
+        "title": "FileMaker: Open Getting Started Walkthrough"
+      },
+      {
+        "command": "filemakerDataApiTools.openUserGuide",
+        "title": "FileMaker: Open User Guide"
+      },
       {
         "command": "filemakerDataApiTools.addConnectionProfile",
         "title": "FileMaker: Add Connection Profile"

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -361,7 +361,62 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     new vscode.Disposable(() => logger.dispose())
   );
 
+  registerWalkthroughCommands(context, logger);
+  void maybeOpenFirstRunWalkthrough(context, logger);
+
   logger.info('FileMaker Data API Tools activated.');
+}
+
+const WALKTHROUGH_ID = 'deffenda.filemaker-data-api-tools#filemakerGettingStarted';
+const FIRST_RUN_FLAG = 'filemaker.walkthrough.shownOnce';
+
+function registerWalkthroughCommands(
+  context: vscode.ExtensionContext,
+  logger: { warn: (message: string, meta?: unknown) => void }
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('filemakerDataApiTools.openWelcomeWalkthrough', async () => {
+      try {
+        await vscode.commands.executeCommand(
+          'workbench.action.openWalkthrough',
+          { category: WALKTHROUGH_ID },
+          false
+        );
+      } catch (error) {
+        logger.warn('Failed to open getting-started walkthrough.', { error });
+      }
+    }),
+    vscode.commands.registerCommand('filemakerDataApiTools.openUserGuide', async () => {
+      try {
+        const uri = vscode.Uri.joinPath(context.extensionUri, 'docs', 'USER_GUIDE.md');
+        await vscode.commands.executeCommand('markdown.showPreview', uri);
+      } catch (error) {
+        logger.warn('Failed to open user guide.', { error });
+      }
+    })
+  );
+}
+
+async function maybeOpenFirstRunWalkthrough(
+  context: vscode.ExtensionContext,
+  logger: { info: (message: string, meta?: unknown) => void; warn: (message: string, meta?: unknown) => void }
+): Promise<void> {
+  if (context.globalState.get<boolean>(FIRST_RUN_FLAG, false)) {
+    return;
+  }
+  // One-shot: mark first so a failure to open the walkthrough doesn't
+  // re-prompt forever on subsequent activations.
+  await context.globalState.update(FIRST_RUN_FLAG, true);
+  try {
+    await vscode.commands.executeCommand(
+      'workbench.action.openWalkthrough',
+      { category: WALKTHROUGH_ID },
+      false
+    );
+    logger.info('First-run getting-started walkthrough opened.');
+  } catch (error) {
+    logger.warn('First-run walkthrough open failed; skipping.', { error });
+  }
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
## Summary
Before: extension activated silently with no walkthrough, no activity-bar icon, no welcome state. New users had to guess that anything existed.

This PR adds:
- **Activity-bar icon**: custom \`media/filemaker.svg\` (monochrome \`currentColor\` so it themes correctly). The \`filemakerExplorer\` view moves out of the default Explorer container into a dedicated FileMaker sidebar.
- **Welcome view**: \`contributes.viewsWelcome\` shows Add Profile + Open Walkthrough buttons when no profiles exist.
- **3-step walkthrough**: \`contributes.walkthroughs\` with \`addProfile → connect → openQueryBuilder\`, each step backed by markdown under \`docs/walkthroughs/\`.
- **First-run prompt**: opens the walkthrough automatically on first activation (one-shot \`globalState\` flag set *before* the open attempt so a failure doesn't re-prompt forever).
- **Two new commands**: \`openWelcomeWalkthrough\` and \`openUserGuide\`.

## Test plan
- [x] CI build-test (typecheck, lint, package:check confirms the manifest + bundled assets)
- [ ] Manual: install fresh on a clean profile → walkthrough opens automatically; sidebar shows the FileMaker activity-bar entry with the new icon; clicking the entry reveals 'Connections' view with welcome content.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)