### PR TITLE
A11y: Webview focus management, aria-pressed toggles, password autocomplete (#93)

### DIFF
--- a/extension/src/webviews/connectionWizard/index.ts
+++ b/extension/src/webviews/connectionWizard/index.ts
@@ -294,10 +294,10 @@ export class ConnectionWizardPanel {
     </div>
 
     <div class="form-section">
-      <h2>Authentication Mode</h2>
-      <div class="mode-toggle">
-        <button type="button" id="modeDirectBtn">Direct</button>
-        <button type="button" id="modeProxyBtn">Proxy</button>
+      <h2 id="auth-mode-heading">Authentication Mode</h2>
+      <div class="mode-toggle" role="group" aria-labelledby="auth-mode-heading">
+        <button type="button" id="modeDirectBtn" aria-pressed="true">Direct</button>
+        <button type="button" id="modeProxyBtn" aria-pressed="false">Proxy</button>
       </div>
       <p class="hint" style="margin-top: -8px;">
         <strong>Direct</strong> connects to FileMaker Data API directly.
@@ -333,12 +333,12 @@ export class ConnectionWizardPanel {
       <h2>Credentials</h2>
       <div class="field">
         <label for="username">Username</label>
-        <input id="username" type="text" placeholder="api_user" />
+        <input id="username" type="text" placeholder="api_user" autocomplete="username" />
         <div class="hint">The FileMaker account with fmrest privilege.</div>
       </div>
       <div class="field">
         <label for="password">Password</label>
-        <input id="password" type="password" />
+        <input id="password" type="password" autocomplete="current-password" />
         <div class="hint">Stored securely in VS Code SecretStorage. Never written to disk.</div>
       </div>
     </div>
@@ -352,7 +352,7 @@ export class ConnectionWizardPanel {
       </div>
       <div class="field">
         <label for="proxyApiKey">API Key (optional)</label>
-        <input id="proxyApiKey" type="password" />
+        <input id="proxyApiKey" type="password" autocomplete="off" />
         <div class="hint">Sent as a Bearer token to your proxy. Stored securely.</div>
       </div>
     </div>

--- a/extension/src/webviews/connectionWizard/ui/index.js
+++ b/extension/src/webviews/connectionWizard/ui/index.js
@@ -25,6 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     authMode = 'direct';
     directBtn.classList.add('active');
     proxyBtn.classList.remove('active');
+    directBtn.setAttribute('aria-pressed', 'true');
+    proxyBtn.setAttribute('aria-pressed', 'false');
     directFields.classList.add('visible');
     proxyFields.classList.remove('visible');
     onFormChanged();
@@ -34,6 +36,8 @@ document.addEventListener('DOMContentLoaded', () => {
     authMode = 'proxy';
     proxyBtn.classList.add('active');
     directBtn.classList.remove('active');
+    proxyBtn.setAttribute('aria-pressed', 'true');
+    directBtn.setAttribute('aria-pressed', 'false');
     proxyFields.classList.add('visible');
     directFields.classList.remove('visible');
     onFormChanged();
@@ -42,6 +46,13 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize
   directBtn.classList.add('active');
   directFields.classList.add('visible');
+
+  // Focus the first input so screen-reader + keyboard users land on
+  // something actionable immediately, not at the document root.
+  const firstInput = /** @type {HTMLInputElement|null} */ (document.getElementById('profileName'));
+  if (firstInput) {
+    firstInput.focus();
+  }
 
   // Track every input edit
   form.addEventListener('input', onFormChanged);

--- a/extension/src/webviews/queryBuilder/ui/index.js
+++ b/extension/src/webviews/queryBuilder/ui/index.js
@@ -239,6 +239,12 @@ function applyInit(payload) {
   }
 
   setStatus('Ready.');
+
+  // Focus the profile select once the init data has rendered so SR + keyboard
+  // users land on the primary control instead of the document root.
+  if (profileSelect && typeof profileSelect.focus === 'function') {
+    profileSelect.focus();
+  }
 }
 
 function applyLayouts(payload) {


### PR DESCRIPTION
## Summary
The audit's claim of \"no labels, no ARIA\" was wrong — \`<label for>\` and \`role=\"status\" aria-live=\"polite\"\` are already in place across the 5 source-controlled panels. The actual gaps were focus management and a few semantic refinements.

This PR ships the minimal, safe additions:

**Connection Wizard**
- Mode-toggle buttons get \`role=\"group\"\` + \`aria-labelledby\` and \`aria-pressed\` reflecting which auth mode is active. UI script keeps \`aria-pressed\` in sync with \`class=\"active\"\`.
- \`#profileName\` receives focus on DOMContentLoaded so SR + keyboard users land on a primary control instead of the document root.
- \`username\` / \`password\` / \`proxyApiKey\` gain \`autocomplete\` hints — password managers treat the wizard like a real login form and never offer to save the proxy API key.

**Query Builder**
- \`#profileSelect\` receives focus once \`applyInit\` has rendered, matching the wizard pattern.

No layout changes, no event-flow changes, no test impact. The \`recordEditor\` / \`recordViewer\` / \`scriptRunner\` panels' existing \`role=\"status\"\` + \`aria-live=\"polite\"\` regions were verified in place.

## Test plan
- [x] CI build-test (typecheck + lint over modified files)
- [ ] Manual: open Connection Wizard → Tab lands on Profile Name first. Press Direct/Proxy → \`aria-pressed\` flips. Open Query Builder with one profile → Tab lands on Profile dropdown.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)