### PR TITLE
fix(explorer): show viewsWelcome empty state when no profiles/jobs/env-sets exist (#103)

### DIFF
--- a/extension/src/views/fmExplorer.ts
+++ b/extension/src/views/fmExplorer.ts
@@ -133,8 +133,9 @@ export class FMExplorerProvider implements vscode.TreeDataProvider<FMExplorerIte
 
   private async getRootItems(): Promise<FMExplorerItem[]> {
     const items: FMExplorerItem[] = [];
+    const offlineActive = this.offlineModeService.isOfflineModeEnabled();
 
-    if (this.offlineModeService.isOfflineModeEnabled()) {
+    if (offlineActive) {
       items.push(
         new FMExplorerItem({
           kind: 'offlineBadge',
@@ -151,24 +152,55 @@ export class FMExplorerProvider implements vscode.TreeDataProvider<FMExplorerIte
       );
     }
 
-    const jobsRoot = new FMExplorerItem({
-      kind: 'jobsRoot',
-      label: 'Jobs',
-      collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-      contextValue: 'fmJobsRoot',
-      iconPath: new vscode.ThemeIcon('history')
-    });
+    const profiles = await this.profileStore.listProfiles();
 
-    const envSetsRoot = new FMExplorerItem({
-      kind: 'environmentSetsRoot',
-      label: 'Environment Sets',
-      collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-      contextValue: 'fmEnvironmentSetsRoot',
-      iconPath: new vscode.ThemeIcon('organization')
-    });
+    // Empty-state path: when the user has no profiles yet and nothing else is
+    // demanding attention (offline badge, env sets, jobs), return zero children
+    // so VS Code renders the contributes.viewsWelcome markdown (which holds the
+    // primary "Add Connection Profile" / "Open Walkthrough" CTAs). Putting any
+    // root node here suppresses viewsWelcome and leaves new users staring at
+    // empty collapsibles instead of a real call to action.
+    if (profiles.length === 0) {
+      const envSets = await this.environmentSetStore.listEnvironmentSets();
+      const jobs = this.jobRunner.listJobs();
+      if (!offlineActive && envSets.length === 0 && jobs.length === 0) {
+        return [];
+      }
+    }
 
-    const profileItems = await this.getProfileItems();
-    items.push(envSetsRoot, jobsRoot, ...profileItems);
+    // Hide Environment Sets entirely until the user has at least one set or
+    // we're in a state where env-set children are meaningful. Same idea for
+    // Jobs: don't surface a node that's just going to say "No active jobs".
+    const envSets = await this.environmentSetStore.listEnvironmentSets();
+    if (envSets.length > 0) {
+      items.push(
+        new FMExplorerItem({
+          kind: 'environmentSetsRoot',
+          label: 'Environment Sets',
+          collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+          contextValue: 'fmEnvironmentSetsRoot',
+          iconPath: new vscode.ThemeIcon('organization')
+        })
+      );
+    }
+
+    const jobs = this.jobRunner.listJobs();
+    if (jobs.length > 0) {
+      items.push(
+        new FMExplorerItem({
+          kind: 'jobsRoot',
+          label: 'Jobs',
+          collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+          contextValue: 'fmJobsRoot',
+          iconPath: new vscode.ThemeIcon('history')
+        })
+      );
+    }
+
+    if (profiles.length > 0) {
+      const profileItems = await this.getProfileItems();
+      items.push(...profileItems);
+    }
 
     return items;
   }

--- a/extension/test/unit/views/fmExplorer.test.ts
+++ b/extension/test/unit/views/fmExplorer.test.ts
@@ -23,6 +23,7 @@ function createMockDeps() {
       listSummaries: vi.fn().mockResolvedValue([])
     },
     jobRunner: {
+      listJobs: vi.fn().mockReturnValue([]),
       getJobSummaries: vi.fn().mockReturnValue([])
     },
     environmentSetStore: {
@@ -56,15 +57,14 @@ function createProvider(deps = createMockDeps()) {
 
 describe('FMExplorerProvider', () => {
   describe('getChildren (root)', () => {
-    it('returns environment sets and jobs root nodes when no profiles exist', async () => {
+    it('returns an empty array when nothing exists (lets viewsWelcome render)', async () => {
       const provider = createProvider();
       const children = await provider.getChildren();
 
-      expect(children.length).toBeGreaterThanOrEqual(2);
-
-      const kinds = children.map((c) => c.kind);
-      expect(kinds).toContain('environmentSetsRoot');
-      expect(kinds).toContain('jobsRoot');
+      // Critical: an empty tree triggers contributes.viewsWelcome, which is
+      // where the primary "Add Connection Profile" / "Open Walkthrough" CTAs
+      // live. Any root node here suppresses that welcome view.
+      expect(children).toEqual([]);
     });
 
     it('returns profile nodes when profiles exist', async () => {
@@ -78,6 +78,60 @@ describe('FMExplorerProvider', () => {
       const profileNodes = children.filter((c) => c.kind === 'profile');
       expect(profileNodes).toHaveLength(1);
       expect(profileNodes[0].label).toBe('Dev Server');
+    });
+
+    it('omits Environment Sets root when zero env sets exist', async () => {
+      const deps = createMockDeps();
+      deps.profileStore.listProfiles.mockResolvedValue([
+        { id: 'p1', name: 'Dev', serverUrl: 'https://x', database: 'D', authMode: 'direct' }
+      ]);
+      const provider = createProvider(deps);
+      const children = await provider.getChildren();
+
+      const kinds = children.map((c) => c.kind);
+      expect(kinds).not.toContain('environmentSetsRoot');
+    });
+
+    it('shows Environment Sets root when at least one env set exists', async () => {
+      const deps = createMockDeps();
+      deps.environmentSetStore.listEnvironmentSets.mockResolvedValue([
+        { id: 'e1', name: 'Prod vs Dev', profiles: ['p1', 'p2'], createdAt: '2026-01-01' }
+      ]);
+      deps.profileStore.listProfiles.mockResolvedValue([
+        { id: 'p1', name: 'Dev', serverUrl: 'https://x', database: 'D', authMode: 'direct' }
+      ]);
+      const provider = createProvider(deps);
+      const children = await provider.getChildren();
+
+      const kinds = children.map((c) => c.kind);
+      expect(kinds).toContain('environmentSetsRoot');
+    });
+
+    it('omits Jobs root when no jobs are tracked', async () => {
+      const deps = createMockDeps();
+      deps.profileStore.listProfiles.mockResolvedValue([
+        { id: 'p1', name: 'Dev', serverUrl: 'https://x', database: 'D', authMode: 'direct' }
+      ]);
+      const provider = createProvider(deps);
+      const children = await provider.getChildren();
+
+      const kinds = children.map((c) => c.kind);
+      expect(kinds).not.toContain('jobsRoot');
+    });
+
+    it('shows Jobs root when jobs exist', async () => {
+      const deps = createMockDeps();
+      deps.jobRunner.listJobs = vi.fn().mockReturnValue([
+        { id: 'j1', name: 'Export', status: 'running', progress: 50, startedAt: '2026-01-01' }
+      ]);
+      deps.profileStore.listProfiles.mockResolvedValue([
+        { id: 'p1', name: 'Dev', serverUrl: 'https://x', database: 'D', authMode: 'direct' }
+      ]);
+      const provider = createProvider(deps);
+      const children = await provider.getChildren();
+
+      const kinds = children.map((c) => c.kind);
+      expect(kinds).toContain('jobsRoot');
     });
 
     it('includes offline badge when offline mode is enabled', async () => {


### PR DESCRIPTION
## Summary
- Closes #103 (viewsWelcome dead code)
- getRootItems returns [] when nothing demands attention, letting VS Code render the polished welcome markdown
- Environment Sets / Jobs roots hidden until they have content (less noise for new users)
- Existing offline-badge and profile-population paths unchanged

## Test plan
- [x] fmExplorer.test.ts: 12 tests passing (empty path, env-sets visibility, jobs visibility, offline badge, profile rendering)
- [x] tsc --noEmit clean
- [ ] Manual smoke: install dev build, open the FileMaker activity bar → confirm "Add Connection Profile" CTA visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)