### PR TITLE
feat(package): declare capabilities.untrustedWorkspaces (#109)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -38,6 +38,22 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Reading layout metadata, browsing the FileMaker Explorer, and running Find queries work in untrusted workspaces. Write operations (record edit/create/delete, batch updates, type generation, FM Web project init) and enterprise environment comparisons require a trusted workspace. Trust the workspace via VS Code's banner to enable them.",
+      "restrictedConfigurations": [
+        "filemaker.features.batch.enabled",
+        "filemaker.features.recordEdit.enabled",
+        "filemaker.features.scriptRunner.enabled",
+        "filemaker.enterprise.mode",
+        "filemaker.enterprise.role",
+        "filemaker.batch.maxRecords",
+        "filemaker.batch.concurrency",
+        "filemaker.batch.dryRunDefault"
+      ]
+    }
+  },
   "contributes": {
     "viewsContainers": {
       "activitybar": [


### PR DESCRIPTION
## Summary
- Closes #109
- The extension already has runtime trust gates on every write command, so it activates safely in untrusted workspaces
- Declaring \`capabilities.untrustedWorkspaces.supported = 'limited'\` makes VS Code show its built-in trust banner instead of per-command toasts
- \`restrictedConfigurations\` lists the 8 feature toggles that gate writes, so the Settings UI marks them appropriately

## Test plan
- [x] node validation script passes
- [ ] Manual smoke: open an untrusted folder, confirm VS Code shows the trust banner and the listed settings show 'not editable in untrusted workspaces'

🤖 Generated with [Claude Code](https://claude.com/claude-code)