### PR TITLE
feat(ux): persistent FileMaker connection status bar item (#107)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -136,6 +136,10 @@
         "title": "FileMaker: Disconnect"
       },
       {
+        "command": "filemakerDataApiTools.openConnectionMenu",
+        "title": "FileMaker: Connection Menu"
+      },
+      {
         "command": "filemakerDataApiTools.listLayouts",
         "title": "FileMaker: List Layouts"
       },

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -24,6 +24,7 @@ import { ConnectionWizardPanel } from '../webviews/connectionWizard';
 import { QueryBuilderPanel } from '../webviews/queryBuilder';
 import { RecordViewerPanel } from '../webviews/recordViewer';
 import { retryWithBackoff, type BackoffPolicy } from '../utils/backoff';
+import { showConnectionQuickPick } from '../views/connectionStatusBar';
 
 interface RegisterCoreCommandDeps {
   context: vscode.ExtensionContext;
@@ -34,6 +35,13 @@ interface RegisterCoreCommandDeps {
   logger: Logger;
   roleGuard: RoleGuard;
   refreshExplorer: () => void;
+  /**
+   * Optional callback to re-render the persistent connection status-bar
+   * item after any command that changes the active profile (connect /
+   * disconnect / remove). Wired in extension.ts; left optional so unit
+   * tests don't have to construct a status-bar shim.
+   */
+  refreshConnectionStatus?: () => void;
   onProfileDisconnected?: (profileId: string) => void;
   /** Resolved at call time so settings updates are picked up live. */
   getConnectBackoffPolicy?: () => BackoffPolicy;
@@ -77,6 +85,7 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
     logger,
     roleGuard,
     refreshExplorer,
+    refreshConnectionStatus,
     onProfileDisconnected
   } = deps;
 
@@ -142,6 +151,7 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
         onProfileDisconnected?.(profile.id);
 
         refreshExplorer();
+        refreshConnectionStatus?.();
         vscode.window.showInformationMessage(`Removed profile "${profile.name}".`);
       }
     ),
@@ -188,6 +198,7 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
 
           await profileStore.setActiveProfileId(profile.id);
           refreshExplorer();
+          refreshConnectionStatus?.();
           vscode.window.showInformationMessage(`Connected to "${profile.name}".`);
         } catch (error) {
           await showCommandError(error, {
@@ -208,6 +219,13 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
       await runConnect();
     }),
 
+    vscode.commands.registerCommand('filemakerDataApiTools.openConnectionMenu', async () => {
+      // Backing command for the persistent connection status-bar item. Pops a
+      // quick-pick of contextual actions (Disconnect / Switch / Open Explorer /
+      // Add Profile) and dispatches to the appropriate existing command.
+      await showConnectionQuickPick(profileStore);
+    }),
+
     vscode.commands.registerCommand('filemakerDataApiTools.disconnect', async (arg: unknown) => {
       const profile = await resolveProfileFromArg(arg, profileStore, true);
       if (!profile) {
@@ -223,6 +241,7 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
 
         onProfileDisconnected?.(profile.id);
         refreshExplorer();
+        refreshConnectionStatus?.();
         vscode.window.showInformationMessage(`Disconnected from "${profile.name}".`);
       } catch (error) {
         await showCommandError(error, {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -38,6 +38,7 @@ import { MetricsStore } from './diagnostics/metricsStore';
 import { OfflineModeService } from './offline/offlineModeService';
 import { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
 import { PluginRegistry } from './plugins/pluginRegistry';
+import { ConnectionStatusBar } from './views/connectionStatusBar';
 import { FMExplorerProvider } from './views/fmExplorer';
 import { OfflineStatusBar } from './views/offlineStatusBar';
 
@@ -198,6 +199,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     void refreshPaletteContexts();
   };
 
+  // Persistent connection-state status bar — sits at priority 105 (above the
+  // offline badge, below the transient connect-progress item). Created first
+  // so we can hand its refresh callback to the commands registry.
+  const connectionStatusBar = new ConnectionStatusBar(profileStore);
+
   const coreCommandDisposables = registerCoreCommands({
     context,
     profileStore,
@@ -207,6 +213,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     logger,
     roleGuard,
     refreshExplorer,
+    refreshConnectionStatus: () => connectionStatusBar.refresh(),
     onProfileDisconnected: (profileId) => {
       schemaService.invalidateProfile(profileId);
     },
@@ -346,6 +353,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push(
     offlineStatusBar,
+    connectionStatusBar,
     treeViewDisposable,
     ...coreCommandDisposables,
     ...savedQueryDisposables,

--- a/extension/src/views/connectionStatusBar.ts
+++ b/extension/src/views/connectionStatusBar.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+
+import type { ProfileStore } from '../services/profileStore';
+import type { ConnectionProfile } from '../types/fm';
+
+const STATUS_BAR_PRIORITY = 105;
+const CLICK_COMMAND = 'filemakerDataApiTools.openConnectionMenu';
+
+export interface ConnectionStatusModel {
+  text: string;
+  tooltip: string;
+}
+
+/**
+ * Pure render: chosen so the labeling logic can be unit tested without VS
+ * Code APIs (mirrors the pattern in offlineStatusBar.ts).
+ */
+export function computeConnectionStatus(
+  activeProfile: Pick<ConnectionProfile, 'name' | 'database'> | undefined
+): ConnectionStatusModel {
+  if (!activeProfile) {
+    return {
+      text: '$(circle-outline) FileMaker: Not connected',
+      tooltip: 'No active FileMaker profile. Click for actions.'
+    };
+  }
+  return {
+    text: `$(plug) FileMaker: ${activeProfile.name}`,
+    tooltip: `Connected to ${activeProfile.name} (${activeProfile.database}). Click for actions.`
+  };
+}
+
+/**
+ * Persistent status-bar item that shows "FileMaker: <profile name>" when a
+ * profile is active, and "FileMaker: Not connected" otherwise. The
+ * connect-progress item (priority 110) overrides this briefly during connect
+ * attempts; we sit just under that and above the offline badge (priority 100)
+ * so the visual ordering reads: connect-progress > connection > offline > jobs.
+ *
+ * The previous wizard surface only ever showed a transient "Connected to X"
+ * toast and a status-bar item that disposed itself in finally(). Across
+ * reloads the user had no signal whether a session was alive — which led to
+ * "I'll just run Connect again to be sure" cycles. This item is owned by the
+ * extension host for the lifetime of the activation and is updated whenever
+ * the active profile changes.
+ */
+export class ConnectionStatusBar implements vscode.Disposable {
+  private readonly item: vscode.StatusBarItem;
+
+  public constructor(private readonly profileStore: ProfileStore) {
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      STATUS_BAR_PRIORITY
+    );
+    this.item.command = CLICK_COMMAND;
+    this.item.show();
+    this.refresh();
+  }
+
+  /**
+   * Re-renders the item from the current ProfileStore state. Cheap; safe to
+   * call from any command that changes the active profile (connect,
+   * disconnect, remove, add).
+   */
+  public refresh(): void {
+    const activeProfileId = this.profileStore.getActiveProfileId();
+
+    if (!activeProfileId) {
+      this.applyModel(computeConnectionStatus(undefined));
+      return;
+    }
+
+    // listProfiles is async; renderConnected handles the resolution. Until it
+    // settles, show a placeholder so the user sees SOMETHING immediately
+    // rather than a stale "not connected" label flashing during a connect.
+    this.item.text = '$(plug) FileMaker: …';
+    this.item.tooltip = 'Resolving active profile…';
+    void this.renderConnected(activeProfileId);
+  }
+
+  private async renderConnected(profileId: string): Promise<void> {
+    const profile = await this.profileStore.getProfile(profileId);
+    this.applyModel(computeConnectionStatus(profile));
+  }
+
+  private applyModel(model: ConnectionStatusModel): void {
+    this.item.text = model.text;
+    this.item.tooltip = model.tooltip;
+    this.item.backgroundColor = undefined;
+  }
+
+  public dispose(): void {
+    this.item.dispose();
+  }
+}
+
+/**
+ * Pops a quick-pick with the contextual actions (Switch Profile / Disconnect /
+ * Open Explorer / Add Profile). Exposed as a top-level command so the
+ * status-bar item can wire it as its `command`.
+ */
+export async function showConnectionQuickPick(
+  profileStore: ProfileStore
+): Promise<void> {
+  const activeProfileId = profileStore.getActiveProfileId();
+  const profiles = await profileStore.listProfiles();
+
+  type Pick = vscode.QuickPickItem & { action: string };
+  const items: Pick[] = [];
+
+  if (activeProfileId) {
+    const active = profiles.find((p) => p.id === activeProfileId);
+    items.push({
+      label: '$(debug-disconnect) Disconnect',
+      detail: active ? `From ${active.name}` : undefined,
+      action: 'disconnect'
+    });
+  }
+  if (profiles.length > 0) {
+    items.push({
+      label: activeProfileId ? '$(arrow-swap) Switch Profile…' : '$(plug) Connect…',
+      detail: `${profiles.length} profile${profiles.length === 1 ? '' : 's'} available`,
+      action: 'connect'
+    });
+  }
+  items.push(
+    {
+      label: '$(list-tree) Open FileMaker Explorer',
+      action: 'explorer'
+    },
+    {
+      label: '$(add) Add Connection Profile…',
+      action: 'addProfile'
+    }
+  );
+
+  const choice = await vscode.window.showQuickPick(items, {
+    title: 'FileMaker Connection',
+    placeHolder: activeProfileId
+      ? 'Active profile actions'
+      : 'Not connected — choose an action'
+  });
+  if (!choice) return;
+
+  switch (choice.action) {
+    case 'disconnect':
+      await vscode.commands.executeCommand('filemakerDataApiTools.disconnect');
+      return;
+    case 'connect':
+      await vscode.commands.executeCommand('filemakerDataApiTools.connect');
+      return;
+    case 'explorer':
+      await vscode.commands.executeCommand('filemakerExplorer.focus');
+      return;
+    case 'addProfile':
+      await vscode.commands.executeCommand('filemakerDataApiTools.addConnectionProfile');
+      return;
+  }
+}

--- a/extension/test/unit/views/connectionStatusBar.test.ts
+++ b/extension/test/unit/views/connectionStatusBar.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeConnectionStatus } from '../../../src/views/connectionStatusBar';
+
+describe('computeConnectionStatus', () => {
+  it('renders the disconnected state with a clear CTA tooltip', () => {
+    const model = computeConnectionStatus(undefined);
+    expect(model.text).toBe('$(circle-outline) FileMaker: Not connected');
+    expect(model.tooltip).toContain('No active FileMaker profile');
+    expect(model.tooltip).toContain('Click for actions');
+  });
+
+  it('renders the connected state with the profile name and database', () => {
+    const model = computeConnectionStatus({
+      name: 'Production',
+      database: 'Contacts'
+    });
+    expect(model.text).toBe('$(plug) FileMaker: Production');
+    expect(model.tooltip).toContain('Connected to Production');
+    expect(model.tooltip).toContain('Contacts');
+  });
+
+  it('uses different icons for connected vs disconnected so users can distinguish at a glance', () => {
+    const disc = computeConnectionStatus(undefined);
+    const conn = computeConnectionStatus({ name: 'Dev', database: 'D' });
+    expect(disc.text).toContain('$(circle-outline)');
+    expect(conn.text).toContain('$(plug)');
+    expect(disc.text).not.toBe(conn.text);
+  });
+
+  it('puts the profile name in the visible label so reload/restart shows current state', () => {
+    // The whole point of this status bar item — it persists across reloads
+    // and the user can tell at a glance which profile is active without
+    // re-running Connect "to be sure".
+    const model = computeConnectionStatus({ name: 'Staging-EU', database: 'Sales' });
+    expect(model.text).toContain('Staging-EU');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #107 — biggest \"do I know what state I'm in?\" gap from the hostile UX review
- Permanent status-bar item: \`\$(plug) FileMaker: <profile>\` connected / \`\$(circle-outline) FileMaker: Not connected\` otherwise
- Click pops a quick-pick: Disconnect / Switch Profile / Open Explorer / Add Profile
- Wired to refresh from connect / disconnect / remove paths via new \`refreshConnectionStatus\` callback
- Pure \`computeConnectionStatus()\` function for testability (matches \`computeOfflineStatus\` pattern)

## Test plan
- [x] tsc + vitest: 438 / 438 (4 new tests for status labeling)
- [ ] Manual: connect, reload window, confirm bar still shows connected; disconnect, confirm icon flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)