### PR TITLE
feat(ux): gate advanced commands behind powerUserMode setting (#118)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -569,7 +569,16 @@
         { "command": "filemakerDataApiTools.compareEnvironments", "when": "filemaker.enterpriseMode" },
         { "command": "filemakerDataApiTools.diffLayoutAcrossEnvironments", "when": "filemaker.enterpriseMode" },
         { "command": "filemakerDataApiTools.exportEnvironmentComparisonReport", "when": "filemaker.enterpriseMode" },
-        { "command": "filemakerDataApiTools.openEnvironmentSetJson", "when": "filemaker.enterpriseMode" }
+        { "command": "filemakerDataApiTools.openEnvironmentSetJson", "when": "filemaker.enterpriseMode" },
+
+        { "command": "filemakerDataApiTools.showJobs", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.showRequestHistory", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.openDiagnosticsDashboard", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.showCircuitBreakerStatus", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.reloadPlugins", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.listActivePlugins", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.exportProfiles", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.importProfiles", "when": "filemaker.powerUserMode" }
       ]
     },
     "configuration": {
@@ -712,6 +721,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable batch export/update features (auto-disabled in untrusted workspaces)."
+        },
+        "filemaker.advanced.powerUserMode": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Surface diagnostic / plugin / circuit-breaker / job-runner / import-export commands in the Command Palette. Off by default to keep the FileMaker palette focused on commands new users actually need."
         },
         "filemaker.enterprise.mode": {
           "type": "boolean",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -412,6 +412,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           'setContext',
           'filemaker.enterpriseMode',
           settingsService.isEnterpriseModeEnabled()
+        ),
+        vscode.commands.executeCommand(
+          'setContext',
+          'filemaker.powerUserMode',
+          settingsService.isPowerUserModeEnabled()
         )
       ]);
     } catch (error) {
@@ -421,7 +426,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   void refreshPaletteContexts();
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('filemaker.enterprise.mode')) {
+      if (
+        event.affectsConfiguration('filemaker.enterprise.mode') ||
+        event.affectsConfiguration('filemaker.advanced.powerUserMode')
+      ) {
         void refreshPaletteContexts();
       }
     })

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -244,6 +244,16 @@ export class SettingsService {
     return this.getConfiguration('filemaker').get<boolean>('enterprise.mode', false);
   }
 
+  /**
+   * Controls whether the advanced/diagnostic command palette entries
+   * (Show Jobs, Open Diagnostics Dashboard, Circuit Breaker, plugins,
+   * profile import/export) surface in the FileMaker command palette.
+   * Default false to keep the palette focused for new users.
+   */
+  public isPowerUserModeEnabled(): boolean {
+    return this.getConfiguration('filemaker').get<boolean>('advanced.powerUserMode', false);
+  }
+
   public getEnterpriseRole(): EnterpriseRole {
     const configured = this.getConfiguration('filemaker').get<string>('enterprise.role', 'developer');
     if (configured === 'viewer' || configured === 'developer' || configured === 'admin') {


### PR DESCRIPTION
## Summary
- Closes #118
- New setting \`filemaker.advanced.powerUserMode\` (boolean, default false)
- 8 advanced commands gated behind \`when: filemaker.powerUserMode\`: Show Jobs, Show Request History, Open Diagnostics Dashboard, Show Circuit Breaker Status, Reload Plugins, List Active Plugins, Export Profiles, Import Profiles
- Context key wired into refreshPaletteContexts + config-change listener so toggle takes effect without reload

## Test plan
- [x] tsc + vitest 434/434
- [x] node validation: setting exists with default false
- [ ] Manual: type \"FileMaker:\" in palette → 8 fewer commands by default; flip setting → they appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)