### PR TITLE
fix(ci): proxy package:vsix from root to extension workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "npm run format --workspaces --if-present",
     "format:check": "npm run format:check --workspaces --if-present",
     "package:check": "npm run package:check -w extension",
+    "package:vsix": "npm run package:vsix -w extension",
     "setup": "node ./setup.mjs"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- The v1.1.0 tag CI run failed at the `package` job: `npm error Missing script: package:vsix` at the repo root.
- The script lives only in `extension/package.json`. The sibling `package:check` script already follows the proxy pattern.
- Mirror it for `package:vsix` so tag-triggered `package` + `publish` jobs work.

## Test plan
- [x] `npm run package:vsix` locally builds `artifacts/filemaker-data-api-tools-1.1.0.vsix`.
- [x] `build-test` and `CodeQL` pass on this branch.
- [ ] After merge: delete + re-push v1.1.0 tag; confirm package + publish jobs succeed and Marketplace shows v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)