### PR TITLE
fix(ci): build workspaces before packaging extension VSIX

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "npm run format --workspaces --if-present",
     "format:check": "npm run format:check --workspaces --if-present",
     "package:check": "npm run package:check -w extension",
-    "package:vsix": "npm run package:vsix -w extension",
+    "package:vsix": "npm run build --workspaces --if-present && npm run package:vsix -w extension",
     "setup": "node ./setup.mjs"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- v1.1.0 retag run failed at `package`: `✘ Could not resolve "@fmweb/shared"`.
- Root cause: extension imports the `@fmweb/shared` workspace package; esbuild (via vsce → vscode:prepublish) needs `shared/dist/` before it can resolve it. `build-test` succeeds because it runs `npm run build` (which iterates workspaces) before `package:check`; the dedicated `package` job skipped that.
- Fix: chain `npm run build --workspaces --if-present` into the root `package:vsix` proxy so the deps build is unconditional.

## Test plan
- [x] `npm run package:vsix` from a clean root builds `artifacts/filemaker-data-api-tools-1.1.0.vsix`.
- [x] `build-test` and `CodeQL` pass on this branch.
- [ ] After merge: retag v1.1.0; confirm `package` + `publish` jobs both succeed and Marketplace shows v1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)