### PR TITLE
feat(ci): support CLAUDE_CODE_OAUTH_TOKEN (subscription) as preferred auth

### DIFF
--- a/.github/workflows/claude-code-agent.yml
+++ b/.github/workflows/claude-code-agent.yml
@@ -15,16 +15,24 @@
 #       * Final merge approval: human (you), gated by branch protection
 #
 # Required secrets:
-#   - ANTHROPIC_API_KEY — your Anthropic API key (Marketplace > Manage > Personal API Keys)
-#   - PRS_PAT — a fine-grained PAT with `contents:write`, `pull-requests:write`,
-#       `issues:write` on this repo. Required because PRs opened by GITHUB_TOKEN
-#       do NOT trigger downstream workflows (CI won't fire), so auto-merge stalls.
-#       Skip the PAT and the action falls back to GITHUB_TOKEN — your PRs will
-#       open but you'll have to push an empty commit to trigger CI.
+#   - CLAUDE_CODE_OAUTH_TOKEN (preferred) — your Claude Pro/Max subscription
+#       OAuth token. Generate locally with `claude setup-token`. Format:
+#       sk-ant-oat01-...  Tied to your existing subscription, no pay-per-token.
+#       Token is valid 1 year.
+#       This is what you want if you already pay for Claude Pro/Max.
 #
-# Cost: pay-per-token via ANTHROPIC_API_KEY. Each ticket runs ~1-5 USD depending
-# on complexity. Prompt caching is enabled by the action; ~70% of repeat reads
-# are cached.
+#   - ANTHROPIC_API_KEY (fallback) — pay-per-token Anthropic API key. ONLY
+#       used if CLAUDE_CODE_OAUTH_TOKEN is unset. Most users should NOT use
+#       this — it bills your API account separately from your subscription.
+#
+#   - PRS_PAT (recommended) — a fine-grained PAT with `contents:write`,
+#       `pull-requests:write`, `issues:write` on this repo. PRs opened by
+#       GITHUB_TOKEN do NOT trigger downstream workflows (CI won't fire).
+#       Skip the PAT and the action falls back to GITHUB_TOKEN — PRs open
+#       but you'll have to push an empty commit to trigger CI.
+#
+# Cost: $0 if you use CLAUDE_CODE_OAUTH_TOKEN (subscription absorbs it).
+#       ~$1-5/ticket if you use ANTHROPIC_API_KEY (pay-per-token).
 #
 name: Claude Code Agent
 
@@ -113,7 +121,10 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Prefer Claude Code OAuth (subscription, $0 marginal cost) when set;
+          # fall back to API key (pay-per-token) only if OAuth is unavailable.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           github_token: ${{ secrets.PRS_PAT || secrets.GITHUB_TOKEN }}
           branch_prefix: 'claude/issue-'
           prompt: |

--- a/docs/CLOUD_AGENT.md
+++ b/docs/CLOUD_AGENT.md
@@ -20,16 +20,34 @@ The agent only runs on issues that **currently** carry the `ai/ready-for-work` l
 
 ## Setup (one-time)
 
-### 1. Add the `ANTHROPIC_API_KEY` repo secret
+### 1. Add the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (recommended)
 
-The agent calls the Anthropic API directly. Pay-per-token. Get a key from
-https://console.anthropic.com/settings/keys and add it as a repo secret:
+This uses your existing **Claude Pro/Max subscription** — no pay-per-token API
+charges. Generate the token locally:
 
+```bash
+claude setup-token
 ```
-gh secret set ANTHROPIC_API_KEY --repo deffenda/filemaker-data-api-for-vs-code
+
+That prints a token like `sk-ant-oat01-...` (valid 1 year, tied to your
+subscription, only works with Claude Code). Save it as a repo secret:
+
+```bash
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo deffenda/filemaker-data-api-for-vs-code
+# paste the token when prompted
 ```
 
 Or via the web UI: **Settings → Secrets and variables → Actions → New repository secret**.
+
+> **Cost with this option**: $0 marginal. The action draws from your existing
+> Claude Code subscription quota. You will hit the same rate limits as you
+> would running Claude Code locally.
+
+#### Fallback: `ANTHROPIC_API_KEY` (pay-per-token)
+
+ONLY use this if you don't have a Claude Pro/Max subscription. Get a key from
+https://console.anthropic.com/settings/keys and set it as `ANTHROPIC_API_KEY`.
+Expect ~$1-5 per ticket. The workflow auto-selects OAuth if both are set.
 
 ### 2. (Recommended) Add a `PRS_PAT` repo secret
 
@@ -105,9 +123,12 @@ These are hard rules baked into the prompt + branch protection:
 
 ## Cost
 
-Per ticket, expect $1–5 in Anthropic API charges depending on complexity.
-The 16 tickets currently queued should total under $50. Set a usage limit
-on your API key if you want a hard cap.
+| Auth method | Per-ticket cost | Notes |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max) | **$0 marginal** | Subscription absorbs it. Same rate limits as your local Claude Code. |
+| `ANTHROPIC_API_KEY` (PAYG) | $1–5 | Billed separately. Set an account-level usage cap as a safety net. |
+
+For the 16-ticket batch currently queued: $0 on subscription, or <$50 on PAYG.
 
 ## Failure handling
 
@@ -132,9 +153,12 @@ workflow run. Triage manually: read the run logs, decide whether to retry
 Check **Actions tab → All workflows → Claude Code Agent**. A run should be
 visible within 30 seconds of the label add. If not:
 
-- Verify `ANTHROPIC_API_KEY` is set (Settings → Secrets and variables → Actions).
+- Verify `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY` fallback) is set
+  in Settings → Secrets and variables → Actions.
 - Verify the workflow is enabled.
 - Verify the label name is exactly `ai/ready-for-work` (case-sensitive).
+- If you're using OAuth: tokens expire after 1 year. Re-run
+  `claude setup-token` locally and update the secret.
 
 ### PR opened but CI didn't run
 


### PR DESCRIPTION
## Summary

Follow-up to #148. The merged workflow only supports `ANTHROPIC_API_KEY` (pay-per-token). This PR adds `CLAUDE_CODE_OAUTH_TOKEN` as the primary auth path so users with an existing **Claude Pro/Max subscription** don't pay per-token API charges.

## How it works

`claude setup-token` (run locally) generates a 1-year OAuth token tied to the user's subscription. The action accepts it via `claude_code_oauth_token`.

The workflow auto-selects OAuth when both secrets are set; falls back to API key only when OAuth is unset.

## Cost matrix

| Auth | Per-ticket | Notes |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max) | **\$0 marginal** | Subscription absorbs it |
| `ANTHROPIC_API_KEY` (PAYG) | \$1-5 | Separate billing |

For the 16-ticket queue: **\$0 on subscription**.

## Setup steps for the user

```bash
# 1. Locally — generate the token (one-time, valid 1 year)
claude setup-token

# 2. Paste the sk-ant-oat01-... token as a repo secret
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo deffenda/filemaker-data-api-for-vs-code
```

## Test plan

- [x] Workflow YAML still parses
- [ ] After merge + secret added: dry-run on #129 confirms OAuth auth works
- [ ] Verify no Anthropic API charges accrue for the run (check console.anthropic.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)