### PR TITLE
docs: add MIT LICENSE at repo root (#129)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alan Deffenderfer / ABD Enterprises
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

package.json declares `"license": "MIT"` but the repo had no LICENSE file. This PR adds the standard MIT text so:

- GitHub's license detection works (sidebar will show "MIT License")
- npm audit / license scanners no longer flag the project as unlicensed
- Downstream OSS tooling can correctly attribute the license

Copyright holder: Alan Deffenderfer / ABD Enterprises (matches package.json publisher).

Closes #129

## Test plan
- [x] File exists at /LICENSE with standard MIT text
- [ ] After merge: GitHub repo About sidebar shows "MIT License" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)