### PR TITLE
fix(ci): export CLAUDE_CODE_OAUTH_TOKEN as env var to the Claude action

### DIFF
--- a/.github/workflows/claude-code-agent.yml
+++ b/.github/workflows/claude-code-agent.yml
@@ -119,6 +119,15 @@ jobs:
           gh issue comment "$ISSUE_NUMBER" --body "🤖 Claude Code cloud agent claimed this ticket. Working in branch \`claude/issue-$ISSUE_NUMBER\`."
 
       - name: Run Claude Code
+        # Belt-and-suspenders auth: the @v1 release accepts
+        # claude_code_oauth_token as a `with:` input but does not always
+        # export it to the CLI subprocess as the CLI expects. Setting
+        # CLAUDE_CODE_OAUTH_TOKEN as a job-step env var guarantees the
+        # token is visible to the Claude CLI regardless of how the action
+        # wires its inputs internally. The `with:` input stays so the
+        # action's own bookkeeping (logging, validation) still sees it.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         uses: anthropics/claude-code-action@v1
         with:
           # Prefer Claude Code OAuth (subscription, $0 marginal cost) when set;


### PR DESCRIPTION
## Summary

Three previous runs failed with `Failed to authenticate. API Error: 401 Invalid bearer token` despite a valid OAuth token. Diagnosis from the env block in each run log: the action's `with: claude_code_oauth_token` input was set but the `CLAUDE_CODE_OAUTH_TOKEN` env var (which the underlying Claude CLI reads) was **not** exported. The action's `@v1` release doesn't wire that input through to the CLI subprocess.

Fix: set the env var explicitly on the step, alongside the existing `with:` input. Belt-and-suspenders.

## Evidence

Same OAuth token:
- ✅ Works locally: `claude --print "say hi"` returns a response
- ❌ Fails in CI on three previous runs (26296119084, 26296266692, 26296857431)
- The Run Claude Code env block showed `ANTHROPIC_API_KEY:` empty (correct) AND no `CLAUDE_CODE_OAUTH_TOKEN` env var

## Test plan

- [ ] After merge: reset #129 label to `ai/ready-for-work`, dispatch the workflow, confirm OAuth auth succeeds
- [ ] Confirm the action opens a PR for #129
- [ ] If still 401: rule out token expiry, check action @main vs @v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)