### PR TITLE
docs: add support guide (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A free, open-source VS Code extension for the FileMaker Data API. Full CRUD, query building, schema management, batch operations, and more — all from within VS Code.
 
-**[Extension README](extension/README.md)** | **[Roadmap](docs/roadmap.md)** | **[Architecture](extension/ARCHITECTURE.md)** | **[Contributing](extension/CONTRIBUTING.md)**
+**[Extension README](extension/README.md)** | **[Support](SUPPORT.md)** | **[Roadmap](docs/roadmap.md)** | **[Architecture](extension/ARCHITECTURE.md)** | **[Contributing](extension/CONTRIBUTING.md)**
 
 ## Monorepo Structure
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,48 @@
+# Support
+
+Use this guide to choose the right help path for FileMaker Data API Tools.
+
+## Start Here
+
+- Read the [User Guide](extension/docs/USER_GUIDE.md) for setup, connection profiles, query builder usage, records, schema snapshots, and diagnostics.
+- Follow the built-in walkthrough docs for common first-run tasks:
+  - [Add a connection profile](extension/docs/walkthroughs/add-profile.md)
+  - [Test a connection](extension/docs/walkthroughs/test-connect.md)
+  - [Use the query builder](extension/docs/walkthroughs/query-builder.md)
+- Check existing [GitHub issues](https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/issues) before opening a new one.
+
+## Questions
+
+GitHub Discussions are not enabled for this repository yet. Until they are available, ask usage questions by opening a GitHub issue with the `question` and `triage` labels:
+
+[Ask a question](https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/issues/new?labels=question,triage)
+
+Include your VS Code version, extension version, operating system, FileMaker Server version, and the workflow you are trying to complete.
+
+## Bugs and Feature Requests
+
+- For reproducible defects, open a bug report and include steps to reproduce, expected behavior, actual behavior, Output panel logs, and screenshots when useful.
+- For product ideas, open a feature request and describe the problem, proposed solution, alternatives considered, and FileMaker context.
+
+## Response Times
+
+This is an open-source project maintained as time permits. Typical response targets:
+
+- Security reports: initial acknowledgement within 3 business days.
+- Reproducible bugs with complete details: initial triage within 5 business days.
+- Usage questions and feature requests: best-effort response, usually within 10 business days.
+
+These targets are not a commercial service-level agreement.
+
+## Not Supported
+
+The project does not provide:
+
+- A guaranteed commercial SLA, paid support queue, or emergency production support.
+- FileMaker Server administration, hosting, licensing, or backup support.
+- Recovery of lost FileMaker data, credentials, or server access.
+- Custom development for private databases, layouts, scripts, or business workflows.
+
+## Security Issues
+
+Do not report vulnerabilities in public issues. Follow the private reporting path in [extension/SECURITY.md](extension/SECURITY.md).

--- a/extension/README.md
+++ b/extension/README.md
@@ -129,6 +129,7 @@ npm run package:check
 Additional project docs:
 
 - [User Guide](./docs/USER_GUIDE.md)
+- [Support](../SUPPORT.md)
 - [Architecture](./ARCHITECTURE.md)
 - [Contributing](./CONTRIBUTING.md)
 - [Security](./SECURITY.md)


### PR DESCRIPTION
## Summary
- Added root `SUPPORT.md` with user guide, walkthrough, questions, bug/feature, response time, unsupported scope, and security escalation guidance.
- Linked support from the root README and extension README so GitHub and Marketplace users can find the help path.
- Closes the support-channel documentation scope from #132.

## Test plan
- [x] Verified linked support files exist with `test -f ...` and README references resolve to `SUPPORT.md`
- [x] `git diff --check -- SUPPORT.md README.md extension/README.md`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

Closes #132