### PR TITLE
docs: add security disclosure policy (#151)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Security policy and disclosure routing
+/.github/CODEOWNERS @deffenda
+/.well-known/security.txt @deffenda
+/extension/SECURITY.md @deffenda

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:alan@abdenterprises.com
+Expires: 2027-05-01T00:00:00Z
+Acknowledgments: https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/security/advisories
+Preferred-Languages: en
+Canonical: https://raw.githubusercontent.com/ABD-Enterprises/filemaker-data-api-for-vs-code/main/.well-known/security.txt
+Policy: https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/blob/main/extension/SECURITY.md

--- a/extension/SECURITY.md
+++ b/extension/SECURITY.md
@@ -27,10 +27,19 @@ Primary risks addressed by this extension:
 
 ## Vulnerability Reporting
 
-For security issues, report privately to: `security@example.com` (placeholder).
+For security issues, report privately to: `alan@abdenterprises.com`.
 
 Please include:
 - affected version
 - reproduction steps
 - impact assessment
 - suggested mitigation (if known)
+
+## Disclosure Timeline
+
+- **Acknowledgment:** We aim to acknowledge new vulnerability reports within 48 hours.
+- **Initial assessment:** We aim to confirm impact, affected versions, and expected remediation path within 7 calendar days when enough reproduction detail is available.
+- **Fix window:** We target a fix or mitigation within 90 days of acknowledgment for confirmed vulnerabilities. Critical issues that could expose credentials, session tokens, or FileMaker data should be prioritized for a shorter emergency patch window.
+- **Coordinated disclosure:** Please do not publicly disclose a vulnerability before a fix, mitigation, or mutually agreed disclosure date is available. We will credit reporters when requested and appropriate.
+
+If a report is not actionable because required reproduction details are missing, the timeline pauses until the reporter provides enough information to investigate.


### PR DESCRIPTION
## Summary
- Updated `extension/SECURITY.md` with private reporting contact, 48-hour acknowledgment target, 7-day assessment target, 90-day fix window, and coordinated disclosure guidance.
- Added RFC-style `.well-known/security.txt` with contact, expiration, acknowledgments, preferred language, canonical, and policy fields.
- Added `.github/CODEOWNERS` routing security policy files to `@deffenda`.

## Test plan
- [x] Validated required `security.txt` fields and future `Expires` date with a local Node check
- [x] `git diff --check -- extension/SECURITY.md .well-known/security.txt .github/CODEOWNERS`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run package:check`

Closes #151