### PR TITLE
docs: add architecture decision records (#152)

### DIFF
--- a/docs/ADR/ADR-0001-direct-vs-proxy-authentication-modes.md
+++ b/docs/ADR/ADR-0001-direct-vs-proxy-authentication-modes.md
@@ -1,0 +1,28 @@
+# ADR-0001: Direct vs Proxy Authentication Modes
+
+## Status
+
+Accepted
+
+## Context
+
+The extension needs to support users who can connect directly to FileMaker Server over HTTPS and teams that require a middleware layer between VS Code and FileMaker. Direct access is simpler for individual developers, but some organizations need network segmentation, centralized logging, additional authorization, or custom identity handling outside the extension.
+
+At the same time, credentials must stay out of webviews, logs, settings files, and workspace files. The extension also needs a single command and explorer experience regardless of whether requests are sent directly to FileMaker or through middleware.
+
+## Decision
+
+The extension supports two explicit authentication modes on each connection profile:
+
+- **Direct mode** sends FileMaker Data API requests from VS Code to the configured FileMaker Server. Passwords and session tokens are read through `SecretStore`, and session creation uses FileMaker username/password credentials.
+- **Proxy mode** sends requests to a user-configured proxy endpoint. The proxy receives only the fields needed to route and authenticate against FileMaker: profile id, database, server URL, API base path, and API version path. Human-readable profile names are intentionally omitted from proxy payloads.
+
+The command surface, tree views, query builder, record operations, and script operations use `FMClient` as the shared entry point. `FMClient` delegates proxy-mode calls to `ProxyClient` while preserving the same high-level behavior for callers.
+
+## Consequences
+
+- Users can choose the least complex mode that fits their network and security model.
+- Proxy mode is an explicit trust boundary: a configured proxy can receive enough information to authenticate to FileMaker on the user's behalf.
+- Direct mode remains usable without any additional service.
+- Future identity flows, including organization-specific SSO, can be implemented behind a proxy without expanding the extension's credential model.
+- Tests need to cover both direct and proxy behavior so feature additions do not accidentally bypass proxy mode.

--- a/docs/ADR/ADR-0002-aes-gcm-secretstorage-fallback.md
+++ b/docs/ADR/ADR-0002-aes-gcm-secretstorage-fallback.md
@@ -1,0 +1,29 @@
+# ADR-0002: AES-256-GCM Fallback When VS Code SecretStorage Is Unavailable
+
+## Status
+
+Accepted
+
+## Context
+
+VS Code `SecretStorage` is the preferred storage mechanism for passwords, FileMaker session tokens, and proxy API keys. Some headless, remote-agent, or constrained environments can make `SecretStorage` unavailable or unreliable. Without a fallback, those environments cannot persist secrets across the workflows that require them.
+
+Persisting plaintext secrets in settings, workspace files, or logs is not acceptable. Any fallback also needs to be opt-in so normal desktop users keep the stronger platform-backed `SecretStorage` path.
+
+## Decision
+
+`SecretStore` supports three fallback modes:
+
+- `vscode-only`: default behavior; use VS Code `SecretStorage` and surface errors if it fails.
+- `workspace-state`: encrypt secret values and store the encrypted envelopes in VS Code workspace state.
+- `disabled`: do not persist secrets.
+
+The workspace-state fallback uses AES-256-GCM with random salt, random IV, authentication tag, and a PBKDF2-derived key. The key material includes the VS Code machine id when provided, so encrypted fallback values are not intended to decrypt on a different machine. When `SecretStorage` succeeds again, prior fallback entries for that key are cleared.
+
+## Consequences
+
+- Desktop users continue to rely on VS Code `SecretStorage` by default.
+- Remote or headless environments can opt in to a fallback without storing plaintext credentials.
+- The fallback is still weaker than platform-backed secret storage because encrypted envelopes live in workspace state.
+- Users and maintainers need clear privacy and security documentation explaining when the fallback can be used.
+- Fallback failures must be logged without exposing the secret key or secret value.

--- a/docs/ADR/ADR-0003-profile-cache-key-server-identity.md
+++ b/docs/ADR/ADR-0003-profile-cache-key-server-identity.md
@@ -1,0 +1,31 @@
+# ADR-0003: Profile Cache Keys Include Normalized Server URL
+
+## Status
+
+Accepted
+
+## Context
+
+The extension caches FileMaker metadata such as layout lists and layout schema. Earlier cache keys that only identified the profile or database could become unsafe when a profile was edited to point at a different server, database path, API version, or environment. That could show stale metadata from another server and create confusing or unsafe user workflows.
+
+Cache keys also need to be stable across harmless formatting differences, such as URL case and trailing slashes, while still changing when the actual FileMaker resource changes.
+
+## Decision
+
+Profile cache keys use a versioned format:
+
+```text
+v2::<profileId>::<normalizedServerUrl>::<database>::<apiBasePath>::<apiVersionPath>[::<layout>]
+```
+
+The normalized server URL lowercases the scheme and host, strips default ports, and removes path/trailing slash details because `apiBasePath` carries routing identity separately. The `v2::` prefix allows future key-layout changes to invalidate old keys deliberately.
+
+Cache invalidation uses `cacheKeyMatchesProfile()` rather than ad hoc string matching so callers do not need to know the internal key layout.
+
+## Consequences
+
+- Editing a profile to point at another FileMaker Server changes the cache key and avoids stale metadata reuse.
+- Case and trailing slash differences do not create duplicate cache entries.
+- The key includes both profile id and server identity, preserving auth/trust separation while still recognizing resource changes.
+- Future cache-key format changes can bump the version prefix.
+- Tests should protect against partial profile-id matches, such as invalidating `p1` accidentally matching `p10`.

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+This directory records important architecture decisions for FileMaker Data API Tools.
+
+Use a short, numbered ADR whenever a decision changes system behavior, security posture, persistence format, extension lifecycle, CI/release flow, or a public contract future maintainers will need to understand.
+
+## Format
+
+ADRs use the Michael Nygard-style structure:
+
+- **Status**: Proposed, Accepted, Deprecated, or Superseded.
+- **Context**: The forces, constraints, and problem that led to the decision.
+- **Decision**: The choice made.
+- **Consequences**: The tradeoffs, follow-up work, and operational effects.
+
+## Naming
+
+Use zero-padded sequence numbers:
+
+```text
+ADR-0001-short-decision-title.md
+ADR-0002-short-decision-title.md
+```
+
+Do not renumber ADRs after they are merged. If a decision changes, add a new ADR and mark the old one as superseded.


### PR DESCRIPTION
## Summary
- Added `docs/ADR/README.md` with the ADR format and naming guidance.
- Added three accepted seed ADRs for direct vs proxy authentication, AES-256-GCM SecretStorage fallback, and `v2::` profile cache keys with normalized server identity.

## Test plan
- [x] Validated all three ADR files include Status, Context, Decision, and Consequences sections
- [x] `git diff --check -- docs/ADR`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`

Closes #152