### PR TITLE
ci(release): add changelog release notes generator (#191)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,3 +97,13 @@ jobs:
           npx @vscode/vsce publish --packagePath "$VSIX_PATH" --no-update-package-json
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Create GitHub Release
+        run: |
+          VSIX_PATH="$(echo artifacts/*.vsix)"
+          tools/release-notes.sh "$GITHUB_REF_NAME" \
+            | gh release create "$GITHUB_REF_NAME" "$VSIX_PATH" \
+                --title "$GITHUB_REF_NAME" \
+                --notes-file -
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/tools/release-notes.sh
+++ b/tools/release-notes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <version>" >&2
+  echo "example: $0 v1.1.0" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+version="${1#v}"
+changelog_path="${CHANGELOG_PATH:-extension/CHANGELOG.md}"
+
+if [ ! -f "$changelog_path" ]; then
+  echo "release-notes: changelog not found: $changelog_path" >&2
+  exit 1
+fi
+
+awk -v version="$version" '
+  BEGIN {
+    heading = "## " version
+    in_section = 0
+    found = 0
+  }
+
+  $0 == heading {
+    in_section = 1
+    found = 1
+    next
+  }
+
+  in_section && /^## [^#]/ {
+    exit
+  }
+
+  in_section {
+    lines[++line_count] = $0
+  }
+
+  END {
+    if (!found) {
+      print "release-notes: version not found in changelog: " version > "/dev/stderr"
+      exit 1
+    }
+
+    start = 1
+    while (start <= line_count && lines[start] == "") {
+      start++
+    }
+
+    end = line_count
+    while (end >= start && lines[end] == "") {
+      end--
+    }
+
+    for (i = start; i <= end; i++) {
+      print lines[i]
+    }
+  }
+' "$changelog_path"


### PR DESCRIPTION
## Summary
- Added tools/release-notes.sh to extract a tag version section from extension/CHANGELOG.md.
- Updated tag publish CI to pipe generated notes into gh release create and attach the VSIX asset.
- Keeps GitHub Release notes aligned with the reviewed changelog for #191.

## Test plan
- [x] bash -n tools/release-notes.sh
- [x] tools/release-notes.sh v1.1.0
- [x] missing-version failure check
- [x] ruby YAML parse for .github/workflows/ci.yml
- [x] git diff --check -- .github/workflows/ci.yml tools/release-notes.sh
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test

Closes #191