### PR TITLE
feat(typegen): generate TypeScript API clients (#190)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -253,6 +253,10 @@
         "title": "FileMaker: Generate Snippets for Layout"
       },
       {
+        "command": "filemakerDataApiTools.generateTypeScriptClient",
+        "title": "FileMaker: Generate TypeScript Client"
+      },
+      {
         "command": "filemakerDataApiTools.openGeneratedTypesFolder",
         "title": "FileMaker: Open Generated Types Folder"
       },
@@ -560,6 +564,7 @@
         { "command": "filemakerDataApiTools.generateTypesForLayout", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.generateTypesForAllLayouts", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.generateSnippetsForLayout", "when": "filemaker.hasProfiles" },
+        { "command": "filemakerDataApiTools.generateTypeScriptClient", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.initializeFmWebProject", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.diffSchemaSnapshots", "when": "filemaker.hasSchemaSnapshots" },
         { "command": "filemakerDataApiTools.diffAgainstLatestSnapshot", "when": "filemaker.hasSchemaSnapshots" },

--- a/extension/src/commands/typeGen.ts
+++ b/extension/src/commands/typeGen.ts
@@ -6,6 +6,7 @@ import type { Logger } from '../services/logger';
 import type { ProfileStore } from '../services/profileStore';
 import type { SettingsService } from '../services/settingsService';
 import type { TypeGenService } from '../services/typeGenService';
+import type { ConnectionProfile } from '../types/fm';
 import { parseLayoutArg, promptForLayout, resolveProfileFromArg, showCommandError } from './common';
 
 interface RegisterTypeGenCommandsDeps {
@@ -100,6 +101,48 @@ export function registerTypeGenCommands(deps: RegisterTypeGenCommandsDeps): vsco
       }
     }),
 
+    vscode.commands.registerCommand('filemakerDataApiTools.generateTypeScriptClient', async (arg: unknown) => {
+      if (!ensureTrustedWorkspace()) {
+        return;
+      }
+
+      const contextArg = parseLayoutArg(arg);
+      const profile = await resolveProfileFromArg(contextArg, profileStore, true);
+      if (!profile) {
+        return;
+      }
+
+      const layouts = contextArg.layout
+        ? [contextArg.layout]
+        : await promptForLayouts(profile, fmClient);
+      if (!layouts || layouts.length === 0) {
+        return;
+      }
+
+      const outputDirectory = await promptForOutputDirectory();
+      if (!outputDirectory) {
+        return;
+      }
+
+      try {
+        const artifacts = await typeGenService.generateTypeScriptClient(
+          profile,
+          layouts,
+          outputDirectory
+        );
+        await openGeneratedFile(artifacts.readmePath);
+        vscode.window.showInformationMessage(
+          `Generated TypeScript client for ${artifacts.layouts.length} layout${artifacts.layouts.length === 1 ? '' : 's'}.`
+        );
+      } catch (error) {
+        await showCommandError(error, {
+          fallbackMessage: 'TypeScript client generation failed.',
+          logger,
+          logMessage: 'TypeScript client generation failed.'
+        });
+      }
+    }),
+
     vscode.commands.registerCommand('filemakerDataApiTools.openGeneratedTypesFolder', async () => {
       if (!ensureTrustedWorkspace()) {
         return;
@@ -118,6 +161,33 @@ export function registerTypeGenCommands(deps: RegisterTypeGenCommandsDeps): vsco
       await vscode.commands.executeCommand('revealFileInOS', uri);
     })
   ];
+}
+
+async function promptForLayouts(profile: ConnectionProfile, fmClient: FMClient): Promise<string[] | undefined> {
+  const layouts = await fmClient.listLayouts(profile);
+  const picks = await vscode.window.showQuickPick(
+    layouts.map((layout) => ({ label: layout })),
+    {
+      canPickMany: true,
+      placeHolder: 'Choose layouts to include in the generated TypeScript client'
+    }
+  );
+
+  return picks?.map((pick) => pick.label);
+}
+
+async function promptForOutputDirectory(): Promise<string | undefined> {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  const uris = await vscode.window.showOpenDialog({
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    defaultUri: workspaceFolder?.uri,
+    openLabel: 'Generate Client Here',
+    title: 'Choose TypeScript client output folder'
+  });
+
+  return uris?.[0]?.fsPath;
 }
 
 function ensureTrustedWorkspace(): boolean {

--- a/extension/src/services/typeGenService.ts
+++ b/extension/src/services/typeGenService.ts
@@ -8,7 +8,8 @@ import type {
   ConnectionProfile,
   FileMakerFieldMetadata,
   GeneratedLayoutArtifacts,
-  GeneratedSnippetsArtifacts
+  GeneratedSnippetsArtifacts,
+  GeneratedTypeScriptClientArtifacts
 } from '../types/fm';
 import { hashObject } from '../utils/hash';
 import { createNameMap, toPascalCaseIdentifier } from '../utils/nameSanitize';
@@ -127,6 +128,59 @@ export class TypeGenService {
     };
   }
 
+  public async generateTypeScriptClient(
+    profile: ConnectionProfile,
+    layouts: string[],
+    outputDirectory: string
+  ): Promise<GeneratedTypeScriptClientArtifacts> {
+    if (!this.isWorkspaceTrusted()) {
+      throw new Error('Workspace is untrusted. TypeScript client generation to files is disabled.');
+    }
+
+    const selectedLayouts = normalizeLayouts(layouts);
+    if (selectedLayouts.length === 0) {
+      throw new Error('Choose at least one layout to generate a TypeScript client.');
+    }
+
+    const outputDir = resolve(outputDirectory);
+    await mkdir(outputDir, { recursive: true });
+
+    const schemas: GeneratedClientSchema[] = [];
+    for (const layout of selectedLayouts) {
+      const schema = await this.schemaService.getLayoutSchema(profile, layout);
+      if (!schema.supported) {
+        throw new Error(
+          schema.message ?? `Schema metadata is not available for layout "${layout}".`
+        );
+      }
+      schemas.push({ layout, fields: schema.fields });
+    }
+
+    const generatedAt = new Date().toISOString();
+    const layoutNames = createNameMap(selectedLayouts);
+    const typesContent = renderClientTypes(profile, schemas, layoutNames, generatedAt);
+    const clientContent = renderClientSource(profile, schemas, layoutNames, generatedAt);
+    const readmeContent = renderClientReadme(profile, selectedLayouts, generatedAt);
+
+    const typesPath = resolve(outputDir, 'types.ts');
+    const clientPath = resolve(outputDir, 'client.ts');
+    const readmePath = resolve(outputDir, 'README.md');
+
+    await Promise.all([
+      writeFile(typesPath, typesContent, 'utf8'),
+      writeFile(clientPath, clientContent, 'utf8'),
+      writeFile(readmePath, readmeContent, 'utf8')
+    ]);
+
+    return {
+      directory: outputDir,
+      typesPath,
+      clientPath,
+      readmePath,
+      layouts: selectedLayouts
+    };
+  }
+
   private async writeTypeFile(layout: string, content: string): Promise<string> {
     if (!this.isWorkspaceTrusted()) {
       throw new Error('Workspace is untrusted. Type generation to files is disabled.');
@@ -230,6 +284,11 @@ export interface ${findResponseTypeName} {
   }
 }
 
+interface GeneratedClientSchema {
+  layout: string;
+  fields: FileMakerFieldMetadata[];
+}
+
 function toTsType(field: FileMakerFieldMetadata | undefined): string {
   if (!field) {
     return 'unknown';
@@ -258,6 +317,320 @@ function toTsType(field: FileMakerFieldMetadata | undefined): string {
   }
 
   return 'unknown';
+}
+
+function normalizeLayouts(layouts: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const layout of layouts) {
+    const value = layout.trim();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    normalized.push(value);
+  }
+
+  return normalized;
+}
+
+function renderClientTypes(
+  profile: ConnectionProfile,
+  schemas: GeneratedClientSchema[],
+  layoutNames: ReturnType<typeof createNameMap>,
+  generatedAt: string
+): string {
+  const layoutBlocks = schemas.map((schema) => {
+    const suffix = typeSuffixForLayout(layoutNames, schema.layout);
+    const rows = schema.fields
+      .map((field) => `  ${JSON.stringify(field.name)}?: ${toTsType(field)};`)
+      .join('\n');
+
+    return `export interface ${suffix}FieldData {
+${rows}
+}
+
+export type ${suffix}Record = FileMakerRecord<${suffix}FieldData>;
+
+export interface ${suffix}FindRequest {
+  query: Array<Partial<${suffix}FieldData>>;
+  sort?: Array<Record<string, unknown>>;
+  limit?: number;
+  offset?: number;
+}`;
+  });
+
+  const recordMapRows = schemas
+    .map((schema) => `  ${JSON.stringify(schema.layout)}: ${typeSuffixForLayout(layoutNames, schema.layout)}Record;`)
+    .join('\n');
+  const fieldDataMapRows = schemas
+    .map((schema) => `  ${JSON.stringify(schema.layout)}: ${typeSuffixForLayout(layoutNames, schema.layout)}FieldData;`)
+    .join('\n');
+  const findRequestMapRows = schemas
+    .map((schema) => `  ${JSON.stringify(schema.layout)}: ${typeSuffixForLayout(layoutNames, schema.layout)}FindRequest;`)
+    .join('\n');
+
+  return `/**
+ * AUTO-GENERATED FILE. DO NOT EDIT.
+ * Generated at: ${generatedAt}
+ * Profile: ${profile.name} (${profile.id})
+ * Layouts: ${schemas.map((schema) => schema.layout).join(', ')}
+ */
+
+export interface FileMakerMessage {
+  code: string;
+  message: string;
+}
+
+export interface FileMakerRecord<TFieldData> {
+  recordId: string;
+  modId?: string;
+  fieldData: TFieldData;
+  portalData?: Record<string, Array<Record<string, unknown>>>;
+}
+
+${layoutBlocks.join('\n\n')}
+
+export interface LayoutRecordMap {
+${recordMapRows}
+}
+
+export interface LayoutFieldDataMap {
+${fieldDataMapRows}
+}
+
+export interface LayoutFindRequestMap {
+${findRequestMapRows}
+}
+
+export type LayoutName = keyof LayoutRecordMap;
+`;
+}
+
+function renderClientSource(
+  profile: ConnectionProfile,
+  schemas: GeneratedClientSchema[],
+  layoutNames: ReturnType<typeof createNameMap>,
+  generatedAt: string
+): string {
+  const imports = schemas
+    .flatMap((schema) => {
+      const suffix = typeSuffixForLayout(layoutNames, schema.layout);
+      return [`${suffix}FieldData`, `${suffix}FindRequest`, `${suffix}Record`];
+    })
+    .sort();
+
+  const methods = schemas
+    .map((schema) => renderLayoutClientMethods(schema.layout, typeSuffixForLayout(layoutNames, schema.layout)))
+    .join('\n\n');
+
+  return `/**
+ * AUTO-GENERATED FILE. DO NOT EDIT.
+ * Generated at: ${generatedAt}
+ * Profile: ${profile.name} (${profile.id})
+ */
+
+import type {
+  FileMakerMessage,
+  ${imports.join(',\n  ')}
+} from './types';
+
+export interface FileMakerClientConfig {
+  serverUrl: string;
+  database: string;
+  token: string;
+  apiBasePath?: string;
+  apiVersionPath?: string;
+  fetch?: typeof fetch;
+  headers?: Record<string, string>;
+}
+
+interface DataApiEnvelope<TResponse> {
+  response: TResponse;
+  messages: FileMakerMessage[];
+}
+
+interface FindResponse<TRecord> {
+  data: TRecord[];
+  dataInfo?: Record<string, unknown>;
+}
+
+interface MutateResponse {
+  recordId?: string;
+  modId?: string;
+}
+
+export class FileMakerDataApiClient {
+  private readonly fetchImpl: typeof fetch;
+  private readonly baseUrl: string;
+
+  public constructor(private readonly config: FileMakerClientConfig) {
+    this.fetchImpl = config.fetch ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error('No fetch implementation is available.');
+    }
+
+    const serverUrl = trimSlashes(config.serverUrl);
+    const apiBasePath = trimSlashes(config.apiBasePath ?? 'fmi/data');
+    const apiVersionPath = trimSlashes(config.apiVersionPath ?? 'vLatest');
+    this.baseUrl = \`\${serverUrl}/\${apiBasePath}/\${apiVersionPath}/databases/\${encodeURIComponent(config.database)}\`;
+  }
+
+${indent(methods, 2)}
+
+  private async request<TResponse>(
+    path: string,
+    init: RequestInit
+  ): Promise<DataApiEnvelope<TResponse>> {
+    const response = await this.fetchImpl(\`\${this.baseUrl}\${path}\`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: \`Bearer \${this.config.token}\`,
+        ...this.config.headers,
+        ...init.headers
+      }
+    });
+
+    const text = await response.text();
+    const body = text ? JSON.parse(text) as DataApiEnvelope<TResponse> : undefined;
+
+    if (!response.ok) {
+      const message = body?.messages?.map((item) => item.message).join('; ') || response.statusText;
+      throw new Error(\`FileMaker Data API request failed (\${response.status}): \${message}\`);
+    }
+
+    if (!body) {
+      throw new Error('FileMaker Data API returned an empty response.');
+    }
+
+    return body;
+  }
+}
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\\/+|\\/+$/g, '');
+}
+`;
+}
+
+function renderLayoutClientMethods(layout: string, suffix: string): string {
+  const encodedLayout = `\${encodeURIComponent(${JSON.stringify(layout)})}`;
+
+  return `public async find${suffix}(request: ${suffix}FindRequest): Promise<${suffix}Record[]> {
+  const envelope = await this.request<FindResponse<${suffix}Record>>(
+    \`/layouts/${encodedLayout}/_find\`,
+    {
+      method: 'POST',
+      body: JSON.stringify(request)
+    }
+  );
+  return envelope.response.data;
+}
+
+public async get${suffix}(recordId: string): Promise<${suffix}Record> {
+  const envelope = await this.request<FindResponse<${suffix}Record>>(
+    \`/layouts/${encodedLayout}/records/\${encodeURIComponent(recordId)}\`,
+    { method: 'GET' }
+  );
+  const record = envelope.response.data[0];
+  if (!record) {
+    throw new Error(\`Record not found: \${recordId}\`);
+  }
+  return record;
+}
+
+public async create${suffix}(fieldData: Partial<${suffix}FieldData>): Promise<MutateResponse> {
+  const envelope = await this.request<MutateResponse>(
+    \`/layouts/${encodedLayout}/records\`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ fieldData })
+    }
+  );
+  return envelope.response;
+}
+
+public async edit${suffix}(
+  recordId: string,
+  fieldData: Partial<${suffix}FieldData>
+): Promise<MutateResponse> {
+  const envelope = await this.request<MutateResponse>(
+    \`/layouts/${encodedLayout}/records/\${encodeURIComponent(recordId)}\`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ fieldData })
+    }
+  );
+  return envelope.response;
+}
+
+public async delete${suffix}(recordId: string): Promise<void> {
+  await this.request<Record<string, never>>(
+    \`/layouts/${encodedLayout}/records/\${encodeURIComponent(recordId)}\`,
+    { method: 'DELETE' }
+  );
+}`;
+}
+
+function renderClientReadme(
+  profile: ConnectionProfile,
+  layouts: string[],
+  generatedAt: string
+): string {
+  const firstLayout = layouts[0] ?? 'Layout';
+  const firstMethod = typeSuffixForLayout(createNameMap(layouts), firstLayout);
+
+  return `# FileMaker TypeScript Client
+
+Generated at ${generatedAt} for profile \`${profile.name}\`.
+
+## Files
+
+- \`types.ts\` contains interfaces for the selected layout fields and records.
+- \`client.ts\` contains typed fetch wrappers for find, get, create, edit, and delete operations.
+
+## Usage
+
+\`\`\`ts
+import { FileMakerDataApiClient } from './client';
+
+const client = new FileMakerDataApiClient({
+  serverUrl: 'https://example.filemaker-cloud.com',
+  database: '${escapeReadmeString(profile.database)}',
+  token: process.env.FM_DATA_API_TOKEN ?? ''
+});
+
+const records = await client.find${firstMethod}({
+  query: [{}],
+  limit: 10
+});
+\`\`\`
+
+Selected layouts:
+
+${layouts.map((layout) => `- ${layout}`).join('\n')}
+
+Regenerating this client overwrites these files with a new timestamp.
+`;
+}
+
+function typeSuffixForLayout(layoutNames: ReturnType<typeof createNameMap>, layout: string): string {
+  const friendly = layoutNames.rawToFriendly[layout] ?? sanitizeLayoutFileName(layout);
+  return toPascalCaseIdentifier(friendly);
+}
+
+function indent(value: string, spaces: number): string {
+  const prefix = ' '.repeat(spaces);
+  return value
+    .split('\n')
+    .map((line) => (line.length > 0 ? `${prefix}${line}` : line))
+    .join('\n');
+}
+
+function escapeReadmeString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 function findField(

--- a/extension/src/types/fm.ts
+++ b/extension/src/types/fm.ts
@@ -174,6 +174,14 @@ export interface GeneratedSnippetsArtifacts {
   content: string;
 }
 
+export interface GeneratedTypeScriptClientArtifacts {
+  directory: string;
+  typesPath: string;
+  clientPath: string;
+  readmePath: string;
+  layouts: string[];
+}
+
 export interface RecordDraftValidationError {
   field: string;
   message: string;

--- a/extension/test/unit/typeGenService.test.ts
+++ b/extension/test/unit/typeGenService.test.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, readFile } from 'fs/promises';
+import { mkdtemp, readFile, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import * as ts from 'typescript';
 import { describe, expect, it, vi } from 'vitest';
 
 import { TypeGenService } from '../../src/services/typeGenService';
@@ -76,4 +77,90 @@ describe('TypeGenService', () => {
     expect(snippets.filePath).toContain('snippets/filemaker-data-api.code-snippets');
     expect(snippets.content).toContain('Contacts Find Records');
   });
+
+  it('generates a compiling TypeScript client with typed find results', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'fm-clientgen-'));
+
+    const schemaService = {
+      getLayoutSchema: vi.fn().mockResolvedValue({
+        supported: true,
+        fromCache: false,
+        metadata: { fieldMetaData: [{ name: 'First Name', type: 'text' }] },
+        fields: [
+          { name: 'First Name', type: 'text' },
+          { name: 'Age', type: 'number' }
+        ]
+      })
+    };
+
+    const service = new TypeGenService(schemaService as never, {} as never, {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never, {
+      getWorkspaceRoot: () => root,
+      isWorkspaceTrusted: () => true
+    });
+
+    const artifacts = await service.generateTypeScriptClient(createProfile(), ['Contacts'], root);
+    const types = await readFile(artifacts.typesPath, 'utf8');
+    const client = await readFile(artifacts.clientPath, 'utf8');
+    const readme = await readFile(artifacts.readmePath, 'utf8');
+
+    expect(types).toContain('export interface ContactsFieldData');
+    expect(types).toContain('"First Name"?: string;');
+    expect(types).toContain('"Age"?: number;');
+    expect(client).toContain('public async findContacts');
+    expect(client).toContain('public async createContacts');
+    expect(readme).toContain('Regenerating this client overwrites these files');
+
+    const usagePath = join(root, 'usage.ts');
+    await writeFile(
+      usagePath,
+      `import { FileMakerDataApiClient } from './client';
+
+const fetchImpl: typeof fetch = async () =>
+  new Response(JSON.stringify({ response: { data: [] }, messages: [] }));
+
+const client = new FileMakerDataApiClient({
+  serverUrl: 'https://fm.local',
+  database: 'TestDB',
+  token: 'token',
+  fetch: fetchImpl
 });
+
+async function run(): Promise<string | undefined> {
+  const records = await client.findContacts({ query: [{ "First Name": "Ada" }] });
+  return records[0]?.fieldData["First Name"];
+}
+
+void run;
+`,
+      'utf8'
+    );
+
+    const program = ts.createProgram([artifacts.typesPath, artifacts.clientPath, usagePath], {
+      noEmit: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
+      skipLibCheck: true
+    });
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+
+    expect(diagnostics.map(formatDiagnostic)).toEqual([]);
+  });
+});
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+  if (!diagnostic.file || diagnostic.start === undefined) {
+    return message;
+  }
+
+  const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+  return `${diagnostic.file.fileName}:${position.line + 1}:${position.character + 1} ${message}`;
+}


### PR DESCRIPTION
## Summary
- Added FileMaker: Generate TypeScript Client for the active profile and selected layouts.
- Generates types.ts, client.ts, and README.md into a user-selected directory with generated headers and timestamps.
- Adds typed CRUD fetch wrappers and a compile-backed unit test for generated find usage.

## Test plan
- [x] node package manifest parse
- [x] npm test -- -t TypeGenService (extension)
- [x] npm run typecheck -w extension
- [x] npm run lint -w extension
- [x] git diff --check
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test
- [x] npm run package:check

Closes #190