### PR TITLE
feat(schema): add visual diff modes (#189)

### DIFF
--- a/extension/src/services/schemaDiff.ts
+++ b/extension/src/services/schemaDiff.ts
@@ -21,6 +21,7 @@ export function diffSchemaFields(input: SchemaDiffInput): SchemaDiffResult {
 
   const added: FileMakerFieldMetadata[] = [];
   const removed: FileMakerFieldMetadata[] = [];
+  const unchanged: FileMakerFieldMetadata[] = [];
   const changed: SchemaDiffResult['changed'] = [];
 
   for (const [fieldName, beforeField] of beforeByName.entries()) {
@@ -38,6 +39,8 @@ export function diffSchemaFields(input: SchemaDiffInput): SchemaDiffResult {
         after: afterField,
         changes: attributeChanges
       });
+    } else {
+      unchanged.push(afterField);
     }
   }
 
@@ -55,6 +58,7 @@ export function diffSchemaFields(input: SchemaDiffInput): SchemaDiffResult {
     comparedAt: new Date().toISOString(),
     added: sortFieldsByName(added),
     removed: sortFieldsByName(removed),
+    unchanged: sortFieldsByName(unchanged),
     changed: changed.sort((left, right) => left.fieldName.localeCompare(right.fieldName)),
     summary: {
       added: added.length,

--- a/extension/src/types/fm.ts
+++ b/extension/src/types/fm.ts
@@ -157,6 +157,7 @@ export interface SchemaDiffResult {
   comparedAt: string;
   added: FileMakerFieldMetadata[];
   removed: FileMakerFieldMetadata[];
+  unchanged?: FileMakerFieldMetadata[];
   changed: SchemaFieldChanged[];
   summary: SchemaDiffSummary;
   hasChanges: boolean;

--- a/extension/src/webviews/schemaDiff/index.ts
+++ b/extension/src/webviews/schemaDiff/index.ts
@@ -125,23 +125,26 @@ export class SchemaDiffPanel {
       <p id="meta"></p>
       <div class="summary" id="summary" role="status" aria-live="polite"></div>
       <div class="actions">
+        <div class="mode-switch" role="tablist" aria-label="Schema diff view mode">
+          <button id="sideBySideMode" type="button" role="tab" aria-selected="true">Side by Side</button>
+          <button id="treeMode" type="button" role="tab" aria-selected="false">Tree</button>
+        </div>
+        <label class="filter-toggle">
+          <input id="changesOnly" type="checkbox" />
+          <span>Show only changes</span>
+        </label>
         <button id="exportButton">Export Diff JSON</button>
       </div>
     </header>
 
-    <section>
-      <h2>Added Fields</h2>
-      <div id="added"></div>
+    <section id="sideBySidePanel">
+      <h2>Side by Side</h2>
+      <div id="sideBySide"></div>
     </section>
 
-    <section>
-      <h2>Removed Fields</h2>
-      <div id="removed"></div>
-    </section>
-
-    <section>
-      <h2>Changed Fields</h2>
-      <div id="changed"></div>
+    <section id="treePanel" hidden>
+      <h2>Tree</h2>
+      <div id="tree"></div>
     </section>
   </main>
 

--- a/extension/src/webviews/schemaDiff/ui/index.js
+++ b/extension/src/webviews/schemaDiff/ui/index.js
@@ -2,13 +2,22 @@ const vscode = acquireVsCodeApi();
 
 const meta = document.getElementById('meta');
 const summary = document.getElementById('summary');
-const added = document.getElementById('added');
-const removed = document.getElementById('removed');
-const changed = document.getElementById('changed');
 const exportButton = document.getElementById('exportButton');
+const sideBySideMode = document.getElementById('sideBySideMode');
+const treeMode = document.getElementById('treeMode');
+const changesOnly = document.getElementById('changesOnly');
+const sideBySidePanel = document.getElementById('sideBySidePanel');
+const treePanel = document.getElementById('treePanel');
+const sideBySide = document.getElementById('sideBySide');
+const tree = document.getElementById('tree');
 const diffSections = Array.from(document.querySelectorAll('.container > section'));
 const diffSkeleton = createLoadingSkeleton(['short', 'medium', 'long', 'medium']);
+
+let currentDiff;
+let currentMode = 'side-by-side';
 let diffReady = false;
+
+sideBySideMode.classList.add('active');
 
 diffSections.forEach((section) => {
   section.classList.add('diff-section');
@@ -26,21 +35,56 @@ window.addEventListener('message', (event) => {
     return;
   }
 
-  renderDiff(message.payload);
+  currentDiff = message.payload;
+  renderDiff();
   revealDiff();
+});
+
+sideBySideMode.addEventListener('click', () => {
+  setMode('side-by-side');
+});
+
+treeMode.addEventListener('click', () => {
+  setMode('tree');
+});
+
+changesOnly.addEventListener('change', () => {
+  renderDiff();
 });
 
 exportButton.addEventListener('click', () => {
   vscode.postMessage({ type: 'exportJson' });
 });
 
-function renderDiff(diff) {
-  meta.textContent = `${diff.profileId} • ${diff.layout} • Compared ${diff.comparedAt}`;
-  summary.textContent = `Added ${diff.summary.added}, Removed ${diff.summary.removed}, Changed ${diff.summary.changed}`;
+function setMode(mode) {
+  currentMode = mode;
+  sideBySidePanel.hidden = mode !== 'side-by-side';
+  treePanel.hidden = mode !== 'tree';
+  sideBySideMode.setAttribute('aria-selected', String(mode === 'side-by-side'));
+  treeMode.setAttribute('aria-selected', String(mode === 'tree'));
+  sideBySideMode.classList.toggle('active', mode === 'side-by-side');
+  treeMode.classList.toggle('active', mode === 'tree');
+  renderDiff();
+}
 
-  renderSimpleTable(added, diff.added || []);
-  renderSimpleTable(removed, diff.removed || []);
-  renderChanged(changed, diff.changed || []);
+function renderDiff() {
+  if (!currentDiff) {
+    return;
+  }
+
+  const fieldRows = buildFieldRows(currentDiff);
+  const visibleRows = changesOnly.checked
+    ? fieldRows.filter((row) => row.status !== 'unchanged')
+    : fieldRows;
+
+  meta.textContent = `${currentDiff.profileId} • ${currentDiff.layout} • Compared ${currentDiff.comparedAt}`;
+  summary.textContent = `Added ${currentDiff.summary.added}, Removed ${currentDiff.summary.removed}, Changed ${currentDiff.summary.changed}`;
+
+  if (currentMode === 'side-by-side') {
+    renderSideBySide(visibleRows);
+  } else {
+    renderTree(visibleRows);
+  }
 
   diffSections.forEach((section) => {
     section.classList.remove('loaded');
@@ -53,67 +97,186 @@ function renderDiff(diff) {
   });
 }
 
-function renderSimpleTable(container, rows) {
-  if (!rows.length) {
-    container.replaceChildren(createEmptyMessage('None'));
-    return;
-  }
+function buildFieldRows(diff) {
+  const rows = [];
 
-  const wrapper = document.createElement('div');
-  wrapper.className = 'table-scroll-wrapper';
-
-  const table = document.createElement('table');
-  const thead = document.createElement('thead');
-  const headerRow = document.createElement('tr');
-  ['Field', 'Type', 'Repetitions'].forEach((heading) => {
-    const th = document.createElement('th');
-    th.textContent = heading;
-    headerRow.appendChild(th);
-  });
-  thead.appendChild(headerRow);
-  table.appendChild(thead);
-
-  const tbody = document.createElement('tbody');
-  for (const row of rows) {
-    const tr = document.createElement('tr');
-    [row.name || '', row.type || row.result || '', String(row.repetitions ?? '')].forEach((value) => {
-      const td = document.createElement('td');
-      td.textContent = value;
-      tr.appendChild(td);
+  for (const field of diff.removed || []) {
+    rows.push({
+      name: field.name || '',
+      status: 'removed',
+      before: field,
+      after: undefined,
+      changes: []
     });
-    tbody.appendChild(tr);
   }
 
-  table.appendChild(tbody);
-  wrapper.appendChild(table);
-  container.replaceChildren(wrapper);
+  for (const item of diff.changed || []) {
+    rows.push({
+      name: item.fieldName,
+      status: 'changed',
+      before: item.before,
+      after: item.after,
+      changes: item.changes || []
+    });
+  }
+
+  for (const field of diff.added || []) {
+    rows.push({
+      name: field.name || '',
+      status: 'added',
+      before: undefined,
+      after: field,
+      changes: []
+    });
+  }
+
+  for (const field of diff.unchanged || []) {
+    rows.push({
+      name: field.name || '',
+      status: 'unchanged',
+      before: field,
+      after: field,
+      changes: []
+    });
+  }
+
+  return rows.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function renderChanged(container, rows) {
+function renderSideBySide(rows) {
   if (!rows.length) {
-    container.replaceChildren(createEmptyMessage('None'));
+    sideBySide.replaceChildren(createEmptyMessage('No fields to show'));
     return;
   }
 
-  container.replaceChildren();
-  for (const item of rows) {
-    const block = document.createElement('details');
-    block.className = 'changed-item';
+  const fragment = document.createDocumentFragment();
+  const grid = document.createElement('div');
+  grid.className = 'side-by-side-grid';
+  grid.appendChild(createColumnHeader('Old schema'));
+  grid.appendChild(createColumnHeader('New schema'));
 
-    const summaryLine = document.createElement('summary');
-    summaryLine.textContent = `${item.fieldName} (${item.changes.length} changes)`;
-    block.appendChild(summaryLine);
-
-    const list = document.createElement('ul');
-    for (const change of item.changes) {
-      const li = document.createElement('li');
-      li.textContent = `${change.attribute}: ${JSON.stringify(change.before)} -> ${JSON.stringify(change.after)}`;
-      list.appendChild(li);
-    }
-
-    block.appendChild(list);
-    container.appendChild(block);
+  for (const row of rows) {
+    grid.appendChild(createFieldCell(row.before, row.status, 'before', row.changes));
+    grid.appendChild(createFieldCell(row.after, row.status, 'after', row.changes));
   }
+
+  fragment.appendChild(grid);
+  sideBySide.replaceChildren(fragment);
+}
+
+function createColumnHeader(label) {
+  const header = document.createElement('div');
+  header.className = 'column-header';
+  header.textContent = label;
+  return header;
+}
+
+function createFieldCell(field, status, side, changes) {
+  const cell = document.createElement('article');
+  cell.className = `field-cell ${status} ${side}`;
+
+  if (!field) {
+    cell.appendChild(createStatusBadge(status));
+    cell.appendChild(createEmptyMessage(status === 'added' ? 'Added in new schema' : 'Removed from new schema'));
+    return cell;
+  }
+
+  const title = document.createElement('div');
+  title.className = 'field-title';
+  title.textContent = field.name || '(unnamed field)';
+  cell.appendChild(title);
+  cell.appendChild(createStatusBadge(status));
+
+  const metaList = document.createElement('dl');
+  metaList.className = 'field-meta';
+  appendMeta(metaList, 'Type', field.type || field.result || '');
+  appendMeta(metaList, 'Reps', field.repetitions ?? '');
+  cell.appendChild(metaList);
+
+  if (changes.length > 0) {
+    cell.appendChild(renderChangeList(changes));
+  }
+
+  return cell;
+}
+
+function appendMeta(list, label, value) {
+  const term = document.createElement('dt');
+  term.textContent = label;
+  const description = document.createElement('dd');
+  description.textContent = String(value || '—');
+  list.append(term, description);
+}
+
+function createStatusBadge(status) {
+  const badge = document.createElement('span');
+  badge.className = `status-badge ${status}`;
+  badge.textContent = status;
+  return badge;
+}
+
+function renderTree(rows) {
+  if (!rows.length) {
+    tree.replaceChildren(createEmptyMessage('No fields to show'));
+    return;
+  }
+
+  const details = document.createElement('details');
+  details.open = true;
+  details.className = 'schema-tree-root';
+
+  const rootSummary = document.createElement('summary');
+  rootSummary.textContent = currentDiff.layout;
+  const count = document.createElement('span');
+  count.className = 'tree-count';
+  count.textContent = `${rows.length} fields`;
+  rootSummary.appendChild(count);
+  details.appendChild(rootSummary);
+
+  const list = document.createElement('ul');
+  list.className = 'schema-tree';
+  for (const row of rows) {
+    list.appendChild(createTreeLeaf(row));
+  }
+  details.appendChild(list);
+
+  tree.replaceChildren(details);
+}
+
+function createTreeLeaf(row) {
+  const item = document.createElement('li');
+  item.className = `tree-leaf ${row.status}`;
+
+  const label = document.createElement('span');
+  label.className = 'tree-field-name';
+  label.textContent = row.name || '(unnamed field)';
+  item.appendChild(label);
+  item.appendChild(createStatusBadge(row.status));
+
+  const field = row.after || row.before;
+  if (field) {
+    const type = document.createElement('span');
+    type.className = 'tree-field-type';
+    type.textContent = field.type || field.result || 'unknown';
+    item.appendChild(type);
+  }
+
+  if (row.changes.length > 0) {
+    item.appendChild(renderChangeList(row.changes));
+  }
+
+  return item;
+}
+
+function renderChangeList(changes) {
+  const list = document.createElement('ul');
+  list.className = 'change-list';
+  for (const change of changes) {
+    const item = document.createElement('li');
+    item.textContent = `${change.attribute}: ${JSON.stringify(change.before)} -> ${JSON.stringify(change.after)}`;
+    list.appendChild(item);
+  }
+  return list;
 }
 
 function createLoadingSkeleton(widths) {

--- a/extension/src/webviews/schemaDiff/ui/styles.css
+++ b/extension/src/webviews/schemaDiff/ui/styles.css
@@ -1,10 +1,18 @@
 :root {
-  --bg: #f8fafc;
-  --panel: #ffffff;
-  --text: #111827;
-  --muted: #5b6472;
-  --border: #d0d7de;
-  --accent: #1d4ed8;
+  --bg: var(--vscode-editor-background, #f8fafc);
+  --panel: var(--vscode-sideBar-background, #ffffff);
+  --text: var(--vscode-editor-foreground, #111827);
+  --muted: var(--vscode-descriptionForeground, #5b6472);
+  --border: var(--vscode-panel-border, #d0d7de);
+  --accent: var(--vscode-button-background, #1f6feb);
+  --accent-text: var(--vscode-button-foreground, #ffffff);
+  --added: #137333;
+  --added-bg: rgba(19, 115, 51, 0.1);
+  --removed: #b3261e;
+  --removed-bg: rgba(179, 38, 30, 0.1);
+  --changed: #9a6700;
+  --changed-bg: rgba(154, 103, 0, 0.12);
+  --unchanged-bg: var(--vscode-editorWidget-background, #f6f8fa);
 }
 
 * {
@@ -13,32 +21,33 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 15% 10%, #d9eaff 0%, var(--bg) 34%);
+  background: var(--bg);
   color: var(--text);
-  font-family: 'Avenir Next', 'Segoe UI', sans-serif;
-  font-size: clamp(0.8rem, 0.85rem + 0.1vw, 0.95rem);
+  font-family: var(--vscode-font-family, 'Segoe UI', sans-serif);
+  font-size: var(--vscode-font-size, 13px);
 }
 
 .container {
-  max-width: min(1200px, 95vw);
+  max-width: min(1320px, 96vw);
   margin: 0 auto;
-  padding: clamp(12px, 2vw, 24px);
+  padding: 20px;
   display: grid;
-  gap: 16px;
+  gap: 14px;
 }
 
 section,
 header {
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: clamp(12px, 2vw, 24px);
+  border-radius: 8px;
+  padding: 16px;
 }
 
 h1,
 h2 {
   margin: 0 0 8px;
-  font-size: clamp(1.1rem, 1.2rem + 0.15vw, 1.5rem);
+  font-size: 1.2rem;
+  letter-spacing: 0;
 }
 
 p {
@@ -52,7 +61,42 @@ p {
 }
 
 .actions {
-  margin-top: 12px;
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.mode-switch {
+  display: inline-flex;
+  gap: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+button {
+  border: none;
+  border-radius: 6px;
+  padding: 7px 10px;
+  background: transparent;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.active,
+#exportButton {
+  background: var(--accent);
+  color: var(--accent-text);
+}
+
+.filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
 }
 
 .diff-section {
@@ -71,7 +115,7 @@ p {
   padding: 20px;
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
 .loading-skeleton .skeleton-line {
@@ -108,46 +152,165 @@ p {
   display: none;
 }
 
-button {
-  border: none;
+.side-by-side-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);
+  gap: 8px;
+}
+
+.column-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  font-weight: 700;
+}
+
+.field-cell {
+  min-height: 86px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  overflow-wrap: anywhere;
+}
+
+.field-cell.added,
+.tree-leaf.added {
+  border-color: var(--added);
+  background: var(--added-bg);
+}
+
+.field-cell.removed,
+.tree-leaf.removed {
+  border-color: var(--removed);
+  background: var(--removed-bg);
+}
+
+.field-cell.changed,
+.tree-leaf.changed {
+  border-color: var(--changed);
+  background: var(--changed-bg);
+}
+
+.field-cell.unchanged,
+.tree-leaf.unchanged {
+  background: var(--unchanged-bg);
+}
+
+.field-title {
+  margin-bottom: 8px;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-weight: 700;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  margin: 0 0 8px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--unchanged-bg);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.status-badge.added {
+  color: var(--added);
+}
+
+.status-badge.removed {
+  color: var(--removed);
+}
+
+.status-badge.changed {
+  color: var(--changed);
+}
+
+.field-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 10px;
+  margin: 0;
+  color: var(--muted);
+}
+
+.field-meta dt {
+  font-weight: 700;
+}
+
+.field-meta dd {
+  margin: 0;
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.schema-tree-root {
+  border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 8px 12px;
-  background: var(--accent);
-  color: #fff;
-  font-weight: 600;
+  padding: 10px;
+}
+
+.schema-tree-root > summary {
   cursor: pointer;
+  font-weight: 700;
 }
 
-table {
-  width: 100%;
-  border-collapse: collapse;
+.tree-count {
+  margin-left: 10px;
+  color: var(--muted);
+  font-weight: 500;
 }
 
-.table-scroll-wrapper {
-  width: 100%;
-  overflow-x: auto;
+.schema-tree {
+  display: grid;
+  gap: 8px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
 }
 
-th,
-td {
-  border-bottom: 1px solid var(--border);
-  text-align: left;
-  padding: 8px;
-  font-family: 'SF Mono', Menlo, monospace;
-  font-size: clamp(0.8rem, 0.85rem + 0.1vw, 0.95rem);
+.tree-leaf {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto minmax(80px, 0.35fr);
+  align-items: start;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 9px;
+}
+
+.tree-field-name,
+.tree-field-type {
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.tree-field-type {
+  color: var(--muted);
+}
+
+.change-list {
+  grid-column: 1 / -1;
+  margin: 6px 0 0 18px;
+  padding: 0;
+  color: var(--muted);
 }
 
 .empty {
   color: var(--muted);
 }
 
-.changed-item {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px;
-  margin-bottom: 8px;
-}
+@media (max-width: 760px) {
+  .container {
+    padding: 12px;
+  }
 
-ul {
-  margin: 8px 0 0 18px;
+  .side-by-side-grid,
+  .tree-leaf {
+    grid-template-columns: 1fr;
+  }
 }

--- a/extension/test/unit/schemaDiff.test.ts
+++ b/extension/test/unit/schemaDiff.test.ts
@@ -9,10 +9,12 @@ describe('schemaDiff', () => {
       layout: 'Contacts',
       beforeFields: [
         { name: 'FirstName', type: 'text', repetitions: 1 },
+        { name: 'StableName', type: 'text', repetitions: 1 },
         { name: 'LegacyCode', type: 'text', repetitions: 1 }
       ],
       afterFields: [
         { name: 'FirstName', type: 'number', repetitions: 1 },
+        { name: 'StableName', type: 'text', repetitions: 1 },
         { name: 'LastName', type: 'text', repetitions: 1 }
       ]
     });
@@ -20,6 +22,7 @@ describe('schemaDiff', () => {
     expect(diff.summary).toEqual({ added: 1, removed: 1, changed: 1 });
     expect(diff.added.map((field) => field.name)).toEqual(['LastName']);
     expect(diff.removed.map((field) => field.name)).toEqual(['LegacyCode']);
+    expect(diff.unchanged?.map((field) => field.name)).toEqual(['StableName']);
     const changed = diff.changed.at(0);
     expect(changed?.fieldName).toBe('FirstName');
     expect(changed?.changes.some((change) => change.attribute === 'type')).toBe(true);
@@ -36,5 +39,6 @@ describe('schemaDiff', () => {
 
     expect(diff.hasChanges).toBe(false);
     expect(diff.summary).toEqual({ added: 0, removed: 0, changed: 0 });
+    expect(diff.unchanged?.map((field) => field.name)).toEqual(['FirstName']);
   });
 });


### PR DESCRIPTION
## Summary
- Replaced the text-only schema diff sections with side-by-side and tree webview modes.
- Added a changes-only filter backed by unchanged field data from the diff service.
- Highlighted added, removed, changed, and unchanged fields at the row/leaf level.

## Test plan
- [x] node --check extension/src/webviews/schemaDiff/ui/index.js
- [x] npm test -- -t schemaDiff (extension)
- [x] npm test -- -t SchemaDiffPanel (extension)
- [x] npm run typecheck -w extension
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test
- [x] npm run package:check

Closes #189