### PR TITLE
ci(deps): tune dependency update policy (#188)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,30 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+      time: "09:00"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 30
+      include:
+        - axios
+        - next
+        - react
+        - react-dom
+        - zod
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+      production-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+      security-patches:
+        applies-to: security-updates
+        patterns:
+          - "*"
     ignore:
       # uuid >=9 has a breaking ESM-first redesign that the @vscode/vsce →
       # @azure/identity → @azure/msal-node transitive chain (still on uuid@^8

--- a/.github/workflows/dependency-auto-merge.yml
+++ b/.github/workflows/dependency-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependency Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-dev-deps:
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Enable auto-merge for safe dev dependencies
+        if: |
+          steps.metadata.outputs.dependency-type == 'direct:development' &&
+          (
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,48 @@
+# Dependency Policy
+
+This repository uses Dependabot for npm dependency updates and GitHub Actions
+for the minimum safe auto-merge path.
+
+## Cadence
+
+| Update class | Cadence | Handling |
+| --- | --- | --- |
+| Development dependencies | Weekly on Monday at 09:00 UTC | Grouped into one `dev-dependencies` PR where Dependabot can group them. Patch and minor direct dev-dependency PRs may auto-merge after required checks pass. |
+| Production dependencies | Monthly effective cadence | Grouped into one `production-dependencies` PR where Dependabot can group them. The npm ecosystem check runs weekly because GitHub requires one npm entry per directory/target branch, and production package names use a 30-day cooldown. Human review is required. |
+| Security updates | Reviewed daily | Grouped as `security-patches` when Dependabot can group security updates. Human review is required unless a maintainer explicitly approves another path. |
+
+## Auto-merge Rules
+
+`.github/workflows/dependency-auto-merge.yml` only enables auto-merge for
+Dependabot pull requests when all of the following are true:
+
+- The actor is `dependabot[bot]`.
+- The PR targets `main` and is not a draft.
+- `dependabot/fetch-metadata` reports `dependency-type` as `direct:development`.
+- The update type is `version-update:semver-patch` or
+  `version-update:semver-minor`.
+- Required checks pass before GitHub completes the auto-merge.
+
+The workflow enables GitHub auto-merge; it does not bypass branch protection or
+merge a PR while required checks are pending or failing.
+
+## Human Review Required
+
+Human review is required for:
+
+- Production dependency updates.
+- Any semver-major update.
+- Security updates, including grouped security patches.
+- Any dependency PR with failing, skipped, or unclear validation.
+- Any dependency PR that changes lockfile structure, build tooling behavior, or
+  extension packaging output in a non-obvious way.
+
+## Audit Routine
+
+- Review Dependabot security alerts each business day.
+- Review grouped development dependency PRs weekly.
+- Review grouped production dependency PRs monthly.
+- Keep `npm audit --omit=dev --audit-level=high` in CI as the minimum automated
+  production-dependency audit gate.
+- When a dependency is intentionally pinned or ignored, keep the reason in
+  `.github/dependabot.yml` next to the rule.


### PR DESCRIPTION
## Summary
- Tuned Dependabot to group npm dev, production, and security update PRs.
- Added a narrow Dependabot auto-merge workflow for direct dev-dependency patch/minor updates after required checks pass.
- Documented dependency cadence, auto-merge boundaries, human-review cases, and audit routine.

## Test plan
- [x] ruby YAML parse for .github/dependabot.yml and dependency-auto-merge.yml
- [x] git diff --check
- [x] npm run lint
- [x] npm run typecheck
- [x] npm test

Closes #188