### PR TITLE
docs(funding): add GitHub Sponsors setup (#186)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# GitHub Sponsors funding sources for this project.
+# See https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# Sponsorship pays for:
+#   - Maintainer time on bug fixes + feature requests
+#   - VS Code Marketplace publisher infrastructure
+#   - Hosting the demo FileMaker sandbox (see #168) once it's online
+#
+# Reporting: spend is summarized quarterly in /docs/FUNDING.md once that
+# document exists. Until then, all funds defray maintainer time.
+
+github: [deffenda]

--- a/docs/FUNDING.md
+++ b/docs/FUNDING.md
@@ -1,0 +1,47 @@
+# Funding
+
+This project is open-source under the MIT license and free to use. If it
+saves you time, sponsorship keeps it maintained.
+
+## How to sponsor
+
+- **GitHub Sponsors**: https://github.com/sponsors/deffenda
+- See the **Sponsor** button at the top of the repository page.
+
+## What sponsorship pays for
+
+In rough priority order:
+
+1. **Maintainer time** on bug triage, security fixes, and feature requests
+   that aren't sponsored directly by enterprise users.
+2. **Marketplace publisher infrastructure** — the publisher account, code
+   signing certificates as they're rolled in, and the supporting tooling.
+3. **Demo FileMaker sandbox** (planned via issue #168) — once online, the
+   sandbox is hosted on real FileMaker Cloud capacity. That's a recurring
+   bill.
+4. **Distribution beyond the VS Code Marketplace** — Open VSX registry
+   (issue #160) submission, Homebrew tap (issue #183), Docker image
+   (issue #185).
+
+## What sponsorship does NOT buy
+
+- **No paid feature priority** — the public roadmap is set by user need, not
+  payment. Enterprises that want guaranteed timelines should reach out
+  directly to discuss a commercial support contract.
+- **No advertising or telemetry** — sponsorship does not change the
+  extension's data handling (see [PRIVACY.md](../PRIVACY.md) once it
+  exists — issue #150).
+- **No commitment of support hours** — sponsorship is goodwill funding, not
+  a support contract.
+
+## Reporting
+
+Quarterly summaries of inflow + how it was spent are posted in GitHub
+Discussions under the Announcements category (once Discussions is
+enabled — issue #134).
+
+## Commercial support
+
+Enterprises needing guaranteed response times, custom features, or
+deployment assistance should email **alan@abdenterprises.com** to
+discuss a commercial support arrangement.

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,5 +1,7 @@
 # FileMaker Data API Tools
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink)](https://github.com/sponsors/deffenda)
+
 FileMaker Data API Tools turns VS Code into a serious FileMaker workspace: connect to a FileMaker server, inspect layouts and metadata, run find requests, edit records, compare schema snapshots, export large result sets, and review diagnostics without leaving the editor.
 
 Built for teams that already live in VS Code:


### PR DESCRIPTION
## Summary
- `.github/FUNDING.yml` enables the Sponsor button on the repo
- `docs/FUNDING.md` documents what sponsorship pays for + reporting cadence
- Sponsor badge added to `extension/README.md`

Closes #186

## Test plan
- [ ] After merge: Sponsor button visible on the repo page
- [ ] After merge: docs/FUNDING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)