### PR TITLE
build(bundle): inline source maps in production VSIX (#178)

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,56 @@
+# Release process
+
+This is the canonical runbook for cutting a release. Companion to the
+release-cadence policy (issue #153) and the rollback playbook (issue #141).
+
+## Versioning
+
+Follow semver, interpreted for a VS Code extension:
+
+- **Patch (`1.1.x`)** — bug fixes, doc-only changes, dependency bumps that
+  don't change behavior.
+- **Minor (`1.x.0`)** — new features, new settings, new walkthroughs,
+  new commands. Backward-compatible.
+- **Major (`x.0.0`)** — breaking changes: removed commands, removed
+  settings (without a migration), schema-snapshot format changes that
+  invalidate prior snapshots. Document the migration path in UPGRADE.md
+  before cutting.
+
+## Source maps
+
+Production VSIX ships **inline source maps** (via
+`esbuild --sourcemap=inline` in the `bundle:extension` script). Trade-off:
+the VSIX grows from ~1.0 MB to ~1.7 MB (+60%). The benefit is that any
+user-reported stack trace points at real source file:line positions
+without us having to publish or fetch separate .map files.
+
+If size becomes a real concern (e.g., for Marketplace download speed in
+constrained networks), switch to external maps and exclude them from the
+VSIX:
+
+```diff
+- "bundle:extension": "esbuild ... --sourcemap=inline --outfile=dist/extension.js"
++ "bundle:extension": "esbuild ... --sourcemap=external --outfile=dist/extension.js"
+```
+
+Then add `dist/extension.js.map` to a separate release artifact and add it
+to `.vscodeignore`. Update this section when you do.
+
+## Cut a release
+
+(Full runbook — see issue #140 for the complete step-by-step.)
+
+1. Branch from green main: `git checkout -b release/vX.Y.Z`
+2. Bump `extension/package.json` version
+3. Add a CHANGELOG section under `## X.Y.Z`
+4. PR, CI green, merge
+5. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z — <theme>"` then `git push origin vX.Y.Z`
+6. CI's `package` + `publish` jobs build the VSIX and publish to Marketplace
+7. Promote the GitHub release from draft to Latest
+8. Verify Marketplace shows new version (~5 min after publish)
+
+## After publish
+
+- Re-attach the CI-built VSIX to the GitHub release if needed
+- Post announcement in Discussions / social per issue #147
+- Update any external docs that mention the previous version

--- a/extension/package.json
+++ b/extension/package.json
@@ -875,7 +875,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "bundle:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --outfile=dist/extension.js",
+    "bundle:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap=inline --outfile=dist/extension.js",
     "build:designer-ui": "node ./scripts/build-designer-ui-if-available.mjs",
     "copy:webviews": "shx mkdir -p dist/webviews/queryBuilder/ui dist/webviews/recordViewer/ui dist/webviews/scriptRunner/ui dist/webviews/schemaDiff/ui dist/webviews/recordEditor/ui dist/webviews/connectionWizard/ui dist/webviews/layoutMode/ui && shx cp -r src/webviews/queryBuilder/ui/* dist/webviews/queryBuilder/ui && shx cp -r src/webviews/recordViewer/ui/* dist/webviews/recordViewer/ui && shx cp -r src/webviews/scriptRunner/ui/* dist/webviews/scriptRunner/ui && shx cp -r src/webviews/schemaDiff/ui/* dist/webviews/schemaDiff/ui && shx cp -r src/webviews/recordEditor/ui/* dist/webviews/recordEditor/ui && shx cp -r src/webviews/connectionWizard/ui/* dist/webviews/connectionWizard/ui && shx cp -r src/webviews/layoutMode/ui/* dist/webviews/layoutMode/ui && sh -c 'if [ -d ../designer-ui/dist ]; then shx cp -r ../designer-ui/dist/* dist/webviews/layoutMode/ui; fi'",
     "build": "npm run build:designer-ui && npm run clean && npm run bundle:extension && npm run copy:webviews",


### PR DESCRIPTION
## Summary
- Adds `--sourcemap=inline` to the `bundle:extension` esbuild command
- Documents the size trade-off in new `docs/RELEASE.md`
- VSIX grows from ~1.0 MB to ~1.7 MB

## Why
Production stack traces from user bug reports currently point at minified positions. Inline source maps fix that without forcing users to install dev tools.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run package:vsix` succeeds — produces 1.7 MB VSIX
- [ ] After merge: deliberately throw a test error in production VSIX; verify stack trace shows real source paths

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)