### PR TITLE
[patch] Add AGENTS.md for Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a VS Code extension monorepo (npm workspaces) for **FileMaker Data API Tools**. Four packages:
+
+| Package | Path | Purpose |
+|---------|------|---------|
+| `shared` | `shared/` | Zod layout schemas + React UI renderer |
+| `designer-ui` | `designer-ui/` | React webview for Layout Mode |
+| `runtime-next` | `runtime-next/` | Next.js template for generated apps |
+| `extension` | `extension/` | The VS Code extension itself |
+
+### Node.js version
+
+Requires **Node.js 20** (see `.nvmrc`). Run `source ~/.nvm/nvm.sh && nvm use 20` before any npm command if the default shell version differs.
+
+### Key commands
+
+All commands documented in the root `README.md` and `extension/CONTRIBUTING.md`. Quick reference:
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Build all | `npm run build` |
+| Lint | `npm run lint` (zero warnings enforced) |
+| Typecheck | `npm run typecheck` |
+| Test | `npm test` |
+| Test + coverage | `npm run test:coverage` |
+| VSIX package check | `npm run package:check` |
+| Dev watch | `npm run dev` |
+
+### Testing
+
+- All tests run headlessly via **Vitest** — no VS Code instance or FileMaker server required.
+- HTTP calls are mocked with **nock** in `extension/test/`.
+- VS Code APIs are mocked in `extension/test/setup.ts`.
+- The `shared` package has no tests; `designer-ui` and `runtime-next` each have their own Vitest suites.
+
+### Build order matters
+
+`shared` must be built before `designer-ui` and `runtime-next` (they depend on `@fmweb/shared`). The root `npm run build` handles this automatically via workspace ordering.
+
+### No external services needed
+
+This is a pure Node.js/TypeScript project. No Docker, databases, or external services are required for building, linting, type-checking, or running tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions to streamline development environment setup for future cloud agents.

## Linked issue

N/A — environment setup, no linked issue.

## Changes

- Added `AGENTS.md` with monorepo overview, Node.js version requirement, key commands reference, testing notes, build order, and external service requirements.

## Acceptance criteria mirror

- [x] AGENTS.md created with accurate dev environment instructions

## Test plan

- `npm run lint` — zero warnings
- `npm run typecheck` — clean across all 4 workspaces
- `npm test` — 470 tests pass (446 extension + 15 designer-ui + 9 runtime-next)
- `npm run build` — all packages build successfully
- `npm run package:check` — VSIX packaging validates

Test output:
[test_coverage_output.log](https://cursor.com/agents/bc-2d6e01f3-7bac-4121-b5f9-cc190b14b9e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_coverage_output.log)

## Changelog entry

- [INTERNAL] Add AGENTS.md with Cursor Cloud development environment instructions


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d6e01f3-7bac-4121-b5f9-cc190b14b9e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d6e01f3-7bac-4121-b5f9-cc190b14b9e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

