### PR TITLE
extension: attribute to ABD Enterprises in README and package.json

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Attributed the extension to ABD Enterprises in README and `package.json`:
+  - new `author` field pointing at `https://abdenterprises.com`
+  - `homepage` now resolves to `abdenterprises.com?ref=vscode` (with the GitHub repo still linked via `repository`)
+  - README opens with an ABD attribution line and closes with a consulting-engagement table for users who need integration, migration, or modernization help
+
 ## 1.1.0
 
 Major usability, accessibility, security, and reliability release.

--- a/extension/README.md
+++ b/extension/README.md
@@ -4,6 +4,8 @@
 
 FileMaker Data API Tools turns VS Code into a serious FileMaker workspace: connect to a FileMaker server, inspect layouts and metadata, run find requests, edit records, compare schema snapshots, export large result sets, and review diagnostics without leaving the editor.
 
+**Built by [ABD Enterprises](https://abdenterprises.com?ref=vscode).** A free, open-source tool for FileMaker developers — distilled from the workflows we use on every client engagement.
+
 Built for teams that already live in VS Code:
 
 - Direct and proxy connection modes
@@ -136,6 +138,22 @@ Additional project docs:
 - [Security](./SECURITY.md)
 - [Upgrade Guide](./UPGRADE.md)
 - [QA Smoke Test (v1.1.0)](./docs/QA/SMOKE_TEST_v1_1_0.md) — manual first-time-user test plan for release validation
+
+## Need help with FileMaker integration?
+
+This extension is free and MIT-licensed. The team behind it — [ABD Enterprises](https://abdenterprises.com?ref=vscode) — has been delivering FileMaker integration, migration, and modernization work since 2005.
+
+If you need a hand with the work behind the tool:
+
+| Engagement | Price | What you get |
+| --- | --- | --- |
+| **Discovery Sprint** | $3,000 / 1 week | Documented requirements + effort estimate |
+| **Integration Audit** | $4,500 / 1 week | Architecture review, gap analysis, prioritized remediation |
+| **Migration Assessment** | $9,000 / 2 weeks | Honest evaluation: modernize within FileMaker, or move on |
+| **Platform Modernization** | $25k – $150k | Execute the chosen path in measured phases |
+| **Retainer** | $5,000 / month | Ongoing maintenance, feature work, FM Server administration |
+
+**Contact:** [registrar@abdenterprises.com](mailto:registrar@abdenterprises.com?subject=From%20VS%20Code%20Extension) · [abdenterprises.com](https://abdenterprises.com?ref=vscode)
 
 ## License
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,6 +5,11 @@
   "version": "1.1.0",
   "publisher": "deffenda",
   "license": "MIT",
+  "author": {
+    "name": "ABD Enterprises",
+    "url": "https://abdenterprises.com?ref=vscode",
+    "email": "registrar@abdenterprises.com"
+  },
   "icon": "docs/marketplace/icon.png",
   "galleryBanner": {
     "color": "#081726",
@@ -14,7 +19,7 @@
     "type": "git",
     "url": "https://github.com/deffenda/filemaker-data-api-for-vs-code.git"
   },
-  "homepage": "https://github.com/deffenda/filemaker-data-api-for-vs-code",
+  "homepage": "https://abdenterprises.com?ref=vscode",
   "bugs": {
     "url": "https://github.com/deffenda/filemaker-data-api-for-vs-code/issues"
   },


### PR DESCRIPTION
## Summary

Adds the ABD Enterprises attribution that was in-progress on the working tree before this docs sweep started:

- New `author` field in `extension/package.json` (name, url, email)
- `homepage` redirected from the GitHub repo URL to `abdenterprises.com?ref=vscode` (GitHub URL still linked via `repository`)
- README opens with an ABD attribution line and closes with a consulting-engagement table for users who need integration, migration, or modernization help
- CHANGELOG: new `## Unreleased` section above the 1.1.0 entry

## Why

Attribution alignment with the ABD Enterprises org the repo now lives under, plus a clear path for users who want professional help beyond what the free MIT-licensed extension provides.

## Conflict resolution notes

The original WIP was authored against version `1.0.0` before `1.1.0` shipped on main. Conflict resolution:
- Kept upstream `version: 1.1.0` and the longer marketing description (dropped the stash's stale `1.0.0` + short description)
- Moved the genuinely-new attribution bullets into a fresh `## Unreleased` section instead of appending into the 1.1.0 entry (the stash's other bullets were already captured under 1.1.0 and were dropped to avoid duplication)
- README attribution paragraphs applied cleanly with no conflict

## Follow-up

A second PR will canonicalize remaining `deffenda/filemaker-data-api-for-vs-code` URL references (the `repository.url`, `bugs.url`, and a few docs links) to point at `ABD-Enterprises/...` directly rather than rely on GitHub transfer redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)