### PR TITLE
docs: canonicalize GitHub URLs to ABD-Enterprises org

### DIFF
--- a/docs/CLOUD_AGENT.md
+++ b/docs/CLOUD_AGENT.md
@@ -33,7 +33,7 @@ That prints a token like `sk-ant-oat01-...` (valid 1 year, tied to your
 subscription, only works with Claude Code). Save it as a repo secret:
 
 ```bash
-gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo deffenda/filemaker-data-api-for-vs-code
+gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo ABD-Enterprises/filemaker-data-api-for-vs-code
 # paste the token when prompted
 ```
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -25,7 +25,7 @@ Useful when you need a specific version, pre-release builds, or air-gapped insta
 ```bash
 # Download the VSIX from the GitHub release of your choice:
 curl -L -o filemaker-data-api-tools-1.1.0.vsix \
-  https://github.com/deffenda/filemaker-data-api-for-vs-code/releases/download/v1.1.0/filemaker-data-api-tools-1.1.0.vsix
+  https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/releases/download/v1.1.0/filemaker-data-api-tools-1.1.0.vsix
 
 # Install:
 code --install-extension filemaker-data-api-tools-1.1.0.vsix
@@ -81,7 +81,7 @@ lifecycle.
 
 ## Reporting an install bug
 
-Open an issue at https://github.com/deffenda/filemaker-data-api-for-vs-code/issues
+Open an issue at https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/issues
 with the title prefixed `install:`. Include:
 
 - Your install path (Marketplace / VSIX / brew)

--- a/extension/docs/QA/SMOKE_TEST_v1_1_0.md
+++ b/extension/docs/QA/SMOKE_TEST_v1_1_0.md
@@ -92,7 +92,7 @@ Skip this scenario if SC-01 passed. Use it if Marketplace install is unavailable
 **Precondition:** Clean VS Code.
 
 **Steps:**
-1. Download the VSIX from https://github.com/deffenda/filemaker-data-api-for-vs-code/releases/download/v1.1.0/filemaker-data-api-tools-1.1.0.vsix
+1. Download the VSIX from https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/releases/download/v1.1.0/filemaker-data-api-tools-1.1.0.vsix
 2. In a terminal: `code --install-extension ~/Downloads/filemaker-data-api-tools-1.1.0.vsix`
 3. Restart VS Code.
 
@@ -524,4 +524,4 @@ If any scenario fails:
 
 1. Capture: VS Code version, macOS version, the failing screenshot, and the relevant Output panel logs (`View → Output → FileMaker Data API Tools` dropdown).
 2. If a webview is involved, also capture Developer Tools console (`Help → Toggle Developer Tools`).
-3. Open a new issue at https://github.com/deffenda/filemaker-data-api-for-vs-code/issues with a title like `v1.1.0 QA: SC-XX <short failure description>`. Attach the smoke test issue link.
+3. Open a new issue at https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/issues with a title like `v1.1.0 QA: SC-XX <short failure description>`. Attach the smoke test issue link.

--- a/extension/docs/USER_GUIDE.md
+++ b/extension/docs/USER_GUIDE.md
@@ -9,7 +9,7 @@
 
 ## Installing the Extension
 
-1. Download `filemaker-data-api-tools-1.0.0.vsix` from [GitHub Releases](https://github.com/deffenda/filemaker-data-api-for-vs-code/releases).
+1. Download `filemaker-data-api-tools-1.0.0.vsix` from [GitHub Releases](https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/releases).
 2. Open VS Code.
 3. Press `Cmd+Shift+P` (macOS) or `Ctrl+Shift+P` (Windows/Linux) to open the Command Palette.
 4. Type **Extensions: Install from VSIX...** and select it.

--- a/extension/package.json
+++ b/extension/package.json
@@ -12,11 +12,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/deffenda/filemaker-data-api-for-vs-code.git"
+    "url": "https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code.git"
   },
   "homepage": "https://github.com/deffenda/filemaker-data-api-for-vs-code",
   "bugs": {
-    "url": "https://github.com/deffenda/filemaker-data-api-for-vs-code/issues"
+    "url": "https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/issues"
   },
   "engines": {
     "vscode": "^1.96.0"
@@ -902,7 +902,7 @@
     "test:coverage": "vitest run --coverage",
     "vscode:prepublish": "npm run build",
     "typecheck": "tsc -p . --noEmit",
-    "package:vsix": "shx mkdir -p ../artifacts && vsce package --no-dependencies --allow-missing-repository --baseContentUrl https://github.com/deffenda/filemaker-data-api-for-vs-code/blob/main/extension --baseImagesUrl https://raw.githubusercontent.com/deffenda/filemaker-data-api-for-vs-code/main/extension --out ../artifacts/filemaker-data-api-tools-${npm_package_version}.vsix",
+    "package:vsix": "shx mkdir -p ../artifacts && vsce package --no-dependencies --allow-missing-repository --baseContentUrl https://github.com/ABD-Enterprises/filemaker-data-api-for-vs-code/blob/main/extension --baseImagesUrl https://raw.githubusercontent.com/ABD-Enterprises/filemaker-data-api-for-vs-code/main/extension --out ../artifacts/filemaker-data-api-tools-${npm_package_version}.vsix",
     "package:check": "npm run package:vsix"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Replaces 9 stale `deffenda/filemaker-data-api-for-vs-code` URL references with the canonical `ABD-Enterprises/filemaker-data-api-for-vs-code`. All references currently resolve via GitHub's account-transfer redirect; this makes the canonical home explicit.

Files touched:
- `extension/package.json` — `repository.url`, `bugs.url`, and the `package:vsix` script's `--baseContentUrl` / `--baseImagesUrl` (the latter affects Marketplace listing image/link resolution)
- `extension/docs/USER_GUIDE.md`, `extension/docs/QA/SMOKE_TEST_v1_1_0.md` — download + issues links
- `docs/INSTALL.md` — VSIX download URL + issues URL
- `docs/CLOUD_AGENT.md` — `gh secret set --repo` identifier

## Intentionally not changed

- `extension/package.json` `homepage` — the companion attribution PR (#219) is repointing this to `abdenterprises.com?ref=vscode`. Touching it here would create a merge conflict.
- `.ai/config.json` — local-only per the EAS adapter convention.

## Audit notes for the docs pass

Top-level `README.md` is in good shape (concise monorepo overview + commands table). One minor stale reference noted: it still says "extension v1.0.0" in the Monorepo Structure table — extension shipped 1.1.0. Not URL-canonicalization scope; flagging as a follow-up for the maintainer.

## Test plan

- [x] `grep -rln 'deffenda/filemaker' .` returns only the intentionally-skipped `package.json:17` (homepage) and `.ai/config.json` (local-only)
- [x] `node -e "JSON.parse(...)"` on `extension/package.json` validates
- [x] Diff stat is symmetric (9 ins / 9 del)
- [ ] CI runs the validate.sh + workflow checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)