### PR TITLE
docs: add TypeDoc API reference publishing

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,59 @@
+name: API Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Generate API Docs
+        run: npm run docs:api
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Stage API Docs
+        run: |
+          mkdir -p pages/api
+          touch pages/.nojekyll
+          cp -R docs/api/. pages/api/
+
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: pages
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 build
 coverage
 .worktrees/
+docs/api/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A free, open-source VS Code extension for the FileMaker Data API. Full CRUD, query building, schema management, batch operations, and more — all from within VS Code.
 
-**[Extension README](extension/README.md)** | **[Release Cadence](docs/RELEASE_CADENCE.md)** | **[Roadmap](docs/roadmap.md)** | **[Architecture](extension/ARCHITECTURE.md)** | **[Contributing](extension/CONTRIBUTING.md)**
+**[Extension README](extension/README.md)** | **[API Reference](https://abd-enterprises.github.io/filemaker-data-api-for-vs-code/api/)** | **[Release Cadence](docs/RELEASE_CADENCE.md)** | **[Roadmap](docs/roadmap.md)** | **[Architecture](extension/ARCHITECTURE.md)** | **[Contributing](extension/CONTRIBUTING.md)**
 
 ## Monorepo Structure
 
@@ -37,6 +37,7 @@ Launch the extension:
 | `npm run test:coverage` | Run tests with coverage reporting |
 | `npm run typecheck` | Type-check all workspaces |
 | `npm run lint` | Lint all workspaces |
+| `npm run docs:api` | Generate TypeDoc API reference into `docs/api` |
 | `npm run package:check` | Validate VSIX packaging |
 
 ## Extension Packaging

--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -3,6 +3,7 @@ src/**
 test/**
 dist/**/*.map
 tsconfig*.json
+typedoc.json
 vitest.config.ts
 ../**
 node_modules/**

--- a/extension/ARCHITECTURE.md
+++ b/extension/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 The extension is organized around service boundaries with a thin command/webview layer. Services handle all business logic and Data API communication. Commands and webviews are thin entry points that delegate to services.
 
+Generated API documentation for `src/services` and `src/types` is published at [abd-enterprises.github.io/filemaker-data-api-for-vs-code/api/](https://abd-enterprises.github.io/filemaker-data-api-for-vs-code/api/). Run `npm run docs:api` from the repository root to regenerate the local TypeDoc output in `docs/api`.
+
 ## Module Boundaries
 
 ### Composition Root

--- a/extension/package.json
+++ b/extension/package.json
@@ -903,6 +903,7 @@
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --max-warnings=0",
     "format": "prettier --write \"**/*.{ts,js,json,md,css,html}\"",
     "format:check": "prettier --check \"**/*.{ts,js,json,md,css,html}\"",
+    "docs:api": "typedoc --options typedoc.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "vscode:prepublish": "npm run build",
@@ -930,6 +931,7 @@
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
     "shx": "^0.4.0",
+    "typedoc": "^0.28.19",
     "typescript": "^5.8.3",
     "vitest": "^4.1.5"
   }

--- a/extension/typedoc.json
+++ b/extension/typedoc.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "name": "FileMaker Data API Tools API",
+  "entryPoints": ["./src/services", "./src/types"],
+  "entryPointStrategy": "expand",
+  "tsconfig": "./tsconfig.json",
+  "out": "../docs/api",
+  "readme": "none",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "intentionallyNotExported": [
+    "BatchServiceOptions",
+    "CaptureSnapshotInput",
+    "ClientRequestControl",
+    "GeneratedLayoutSummary",
+    "JobListener",
+    "JobTask",
+    "OfflineModeService",
+    "SecretLogger",
+    "SettingsServiceOptions",
+    "SnapshotStoreOptions",
+    "TemplateCopySummary",
+    "TypeGenServiceOptions"
+  ],
+  "sort": ["source-order"],
+  "navigation": {
+    "includeGroups": true,
+    "includeCategories": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "prettier": "^3.5.3",
         "rimraf": "^6.0.1",
         "shx": "^0.4.0",
+        "typedoc": "^0.28.19",
         "typescript": "^5.8.3",
         "vitest": "^4.1.5"
       },
@@ -1156,6 +1157,20 @@
     "node_modules/@fmweb/shared": {
       "resolved": "shared",
       "link": true
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -2511,6 +2526,55 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -2728,6 +2792,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2776,6 +2850,13 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
       "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6288,6 +6369,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -8543,6 +8631,30 @@
         "underscore": "^1.12.1"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -9029,6 +9141,22 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yauzl": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "format:check": "npm run format:check --workspaces --if-present",
+    "docs:api": "npm run docs:api -w extension",
     "package:check": "npm run package:check -w extension",
     "package:vsix": "npm run build --workspaces --if-present && npm run package:vsix -w extension",
     "setup": "node ./setup.mjs"


### PR DESCRIPTION
## Summary
- Add TypeDoc to the extension workspace with a `docs:api` script that generates API docs from `extension/src/services` and `extension/src/types` into `docs/api`.
- Add a GitHub Pages workflow that builds the docs on `main`, stages them under `/api/`, and deploys the Pages artifact.
- Link the published API reference from the root README and architecture guide, and keep generated docs/build-only config out of package artifacts.

## Acceptance criteria
- [x] TypeDoc configured for services and types API docs.
- [x] API docs generate locally into `docs/api`.
- [x] GitHub Pages workflow publishes the generated site under `/api/` on main pushes.
- [x] README and architecture docs link to the API reference.

## Validation
- [x] `npm run docs:api`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/api-docs.yml"); puts "api-docs workflow YAML OK"'`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run package:check`
- [x] `npm audit --omit=dev --audit-level=high` (passes; existing moderate `postcss`/`next` advisories remain below the configured CI threshold)

Closes #162