### PR TITLE
[minor] Add post-upgrade What's New walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ PR title prefix matches the highest-tier label added:
 
 ### [FEATURE]
 
-- None.
+- Added a versioned **FileMaker: Show What's New** walkthrough that auto-opens
+  once after upgrades and records the seen extension version.
 
 ### [FIX]
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -42,12 +42,20 @@ to `.vscodeignore`. Update this section when you do.
 
 1. Branch from green main: `git checkout -b release/vX.Y.Z`
 2. Bump `extension/package.json` version
-3. Add a CHANGELOG section under `## X.Y.Z`
-4. PR, CI green, merge
-5. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z — <theme>"` then `git push origin vX.Y.Z`
-6. CI's `package` + `publish` jobs build the VSIX and publish to Marketplace
-7. Promote the GitHub release from draft to Latest
-8. Verify Marketplace shows new version (~5 min after publish)
+3. Update the What's New walkthrough for the new version:
+   - add or update the version entry in `extension/src/extension.ts`
+     (`WHATS_NEW_RELEASES`)
+   - add a matching `contributes.walkthroughs` entry in
+     `extension/package.json`
+   - add 3-5 walkthrough markdown files under
+     `extension/docs/walkthroughs/whats-new-X.Y.Z/`, each with a screenshot
+   - verify **FileMaker: Show What's New** opens the new walkthrough
+4. Add a CHANGELOG section under `## X.Y.Z`
+5. PR, CI green, merge
+6. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z — <theme>"` then `git push origin vX.Y.Z`
+7. CI's `package` + `publish` jobs build the VSIX and publish to Marketplace
+8. Promote the GitHub release from draft to Latest
+9. Verify Marketplace shows new version (~5 min after publish)
 
 ## After publish
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added a versioned **FileMaker: Show What's New** walkthrough that opens once
+  after an extension upgrade and can be reopened from the Command Palette.
+
 - Attributed the extension to ABD Enterprises in README and `package.json`:
   - new `author` field pointing at `https://abdenterprises.com`
   - `homepage` now resolves to `abdenterprises.com?ref=vscode` (with the GitHub repo still linked via `repository`)

--- a/extension/docs/walkthroughs/whats-new-1.1.0/connection-status.md
+++ b/extension/docs/walkthroughs/whats-new-1.1.0/connection-status.md
@@ -1,0 +1,10 @@
+# Connection status that persists
+
+![Schema and batch tooling visible after connecting](../../marketplace/schema-and-batch.png)
+
+Version 1.1.0 added a persistent status-bar item for the active FileMaker
+profile. It stays visible across reloads so you can tell which profile is
+connected before running a Data API command.
+
+Connect also retries transient network failures and refreshes session tokens
+before expiry, which reduces manual reconnects during longer work sessions.

--- a/extension/docs/walkthroughs/whats-new-1.1.0/guided-onboarding.md
+++ b/extension/docs/walkthroughs/whats-new-1.1.0/guided-onboarding.md
@@ -1,0 +1,13 @@
+# Guided onboarding
+
+![FileMaker Explorer sidebar with a saved profile and layouts](../../marketplace/explorer-overview.png)
+
+Version 1.1.0 added a first-run walkthrough and a quieter Explorer welcome
+view. New users now see the shortest setup path first:
+
+- add a profile
+- test the connection before saving
+- open the Query Builder from a layout
+
+The walkthrough can be reopened from **FileMaker: Open Getting Started
+Walkthrough** whenever a teammate needs the setup path again.

--- a/extension/docs/walkthroughs/whats-new-1.1.0/query-builder.md
+++ b/extension/docs/walkthroughs/whats-new-1.1.0/query-builder.md
@@ -1,0 +1,12 @@
+# Query Builder discoverability
+
+![Query Builder webview with JSON editor, field-name chips, results table](../../marketplace/query-builder.png)
+
+Version 1.1.0 made the Query Builder easier to reach from the Explorer and
+Command Palette. It now supports a faster loop for common Data API tasks:
+
+- select a profile and layout
+- use field-name chips while composing find JSON
+- inspect results inline
+- export JSON or CSV
+- copy `curl` and `fetch` snippets

--- a/extension/docs/walkthroughs/whats-new-1.1.0/resilient-sessions.md
+++ b/extension/docs/walkthroughs/whats-new-1.1.0/resilient-sessions.md
@@ -1,0 +1,11 @@
+# Resilient Data API sessions
+
+![Schema and batch tooling visible after connecting](../../marketplace/schema-and-batch.png)
+
+Version 1.1.0 tightened the recovery path around FileMaker sessions. Error
+toasts now offer direct retry and detail actions, secret persistence has a
+documented fallback mode for headless environments, and offline status is
+visible without opening a diagnostic panel.
+
+The result is less context switching when a profile, network, or storage
+problem interrupts a Data API workflow.

--- a/extension/docs/walkthroughs/whats-new-1.2.0/fm-web-scaffolding.md
+++ b/extension/docs/walkthroughs/whats-new-1.2.0/fm-web-scaffolding.md
@@ -1,0 +1,11 @@
+# FM Web project scaffolding
+
+![FileMaker Explorer sidebar with a saved profile and layouts](../../marketplace/explorer-overview.png)
+
+Version 1.2.0 introduces FM Web project scaffolding for teams that want a
+browser runtime backed by FileMaker metadata. The workflow keeps generated
+runtime files separate from extension state and gives the Command Palette a
+clear path for initializing, syncing, and generating layout pages.
+
+Start from **FileMaker: Generate FM Web Next App** after connecting to the
+profile that owns the layouts you want to expose.

--- a/extension/docs/walkthroughs/whats-new-1.2.0/layout-mode.md
+++ b/extension/docs/walkthroughs/whats-new-1.2.0/layout-mode.md
@@ -1,0 +1,10 @@
+# Layout Mode authoring
+
+![Query Builder webview with JSON editor, field-name chips, results table](../../marketplace/query-builder.png)
+
+Version 1.2.0 adds the Layout Mode entry point for initialized FM Web
+projects. It gives FileMaker layout metadata a dedicated authoring surface so
+you can inspect layout structure before generating browser-rendered pages.
+
+The command appears after an FM Web project is initialized, keeping the default
+Command Palette focused until the workflow is relevant.

--- a/extension/docs/walkthroughs/whats-new-1.2.0/release-visibility.md
+++ b/extension/docs/walkthroughs/whats-new-1.2.0/release-visibility.md
@@ -1,0 +1,10 @@
+# Release visibility after upgrades
+
+![FileMaker Data API Tools icon](../../marketplace/icon.png)
+
+Version 1.2.0 adds a post-upgrade What's New panel. On activation, the
+extension compares the current package version with the last version recorded
+in global state. When the current version is newer, this walkthrough opens
+once and then records the seen version.
+
+You can reopen it any time with **FileMaker: Show What's New**.

--- a/extension/docs/walkthroughs/whats-new-1.2.0/schema-workflows.md
+++ b/extension/docs/walkthroughs/whats-new-1.2.0/schema-workflows.md
@@ -1,0 +1,11 @@
+# Schema and batch workflow polish
+
+![Schema and batch tooling visible after connecting](../../marketplace/schema-and-batch.png)
+
+Version 1.2.0 keeps schema snapshots, visual diffs, type generation, and batch
+jobs grouped around the FileMaker Explorer. The commands are still available
+from the palette, but Explorer actions keep layout-specific work close to the
+profile and layout that produced it.
+
+Use the schema snapshot and generated type commands when you need a stable
+contract for app code, tests, or review.

--- a/extension/package.json
+++ b/extension/package.json
@@ -136,12 +136,94 @@
             ]
           }
         ]
+      },
+      {
+        "id": "filemakerWhatsNew110",
+        "title": "What's New in v1.1.0",
+        "description": "Review the v1.1.0 onboarding, connection, querying, and reliability improvements.",
+        "steps": [
+          {
+            "id": "guidedOnboarding",
+            "title": "Guided onboarding",
+            "description": "The extension now opens a first-run walkthrough and keeps the FileMaker Explorer welcome view focused on the next useful setup action.\n[Open Getting Started](command:filemakerDataApiTools.openWelcomeWalkthrough)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.1.0/guided-onboarding.md"
+            }
+          },
+          {
+            "id": "connectionStatus",
+            "title": "Connection status that persists",
+            "description": "A status-bar item shows the active FileMaker profile across reloads, while Connect uses retry and proactive token refresh to reduce manual reconnects.\n[Connect](command:filemakerDataApiTools.connect)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.1.0/connection-status.md"
+            }
+          },
+          {
+            "id": "queryBuilder",
+            "title": "Query Builder discoverability",
+            "description": "The Query Builder is easier to reach from layouts and includes field-name chips, result export, and snippet copy actions for faster Data API work.\n[Open Query Builder](command:filemakerDataApiTools.openQueryBuilder)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.1.0/query-builder.md"
+            }
+          },
+          {
+            "id": "resilientSessions",
+            "title": "Resilient Data API sessions",
+            "description": "Error toasts now include retry and details actions, SecretStorage has a documented fallback mode, and offline status is visible in the editor chrome.",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.1.0/resilient-sessions.md"
+            }
+          }
+        ]
+      },
+      {
+        "id": "filemakerWhatsNew120",
+        "title": "What's New in v1.2.0",
+        "description": "Review the v1.2.0 FM Web, layout authoring, schema workflow, and release-visibility improvements.",
+        "steps": [
+          {
+            "id": "fmWebScaffolding",
+            "title": "FM Web project scaffolding",
+            "description": "Generate a Next.js runtime project from FileMaker metadata, sync layout data, and keep generated runtime files separate from extension state.\n[Generate FM Web App](command:filemakerDataApiTools.generateFmWebNextApp)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.2.0/fm-web-scaffolding.md"
+            }
+          },
+          {
+            "id": "layoutMode",
+            "title": "Layout Mode authoring",
+            "description": "Open Layout Mode from initialized FM Web projects to inspect layout metadata and prepare browser-rendered FileMaker experiences.\n[Open Layout Mode](command:filemakerDataApiTools.openLayoutMode)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.2.0/layout-mode.md"
+            }
+          },
+          {
+            "id": "schemaWorkflows",
+            "title": "Schema and batch workflow polish",
+            "description": "Schema snapshots, visual diffs, TypeScript generation, and batch jobs are grouped into clearer FileMaker commands and Explorer actions.",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.2.0/schema-workflows.md"
+            }
+          },
+          {
+            "id": "releaseVisibility",
+            "title": "Release visibility after upgrades",
+            "description": "After a version bump, this What's New walkthrough opens once, then stores the seen version so skipping the panel does not reopen it next launch.\n[Show What's New](command:filemakerDataApiTools.showWhatsNew)",
+            "media": {
+              "markdown": "docs/walkthroughs/whats-new-1.2.0/release-visibility.md"
+            }
+          }
+        ]
       }
     ],
     "commands": [
       {
         "command": "filemakerDataApiTools.openWelcomeWalkthrough",
         "title": "FileMaker: Open Getting Started Walkthrough"
+      },
+      {
+        "command": "filemakerDataApiTools.showWhatsNew",
+        "title": "FileMaker: Show What's New"
       },
       {
         "command": "filemakerDataApiTools.openUserGuide",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -83,8 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const secretFallbackMode = settingsService.getSecretsFallbackMode();
   const secretStore = new SecretStore(context.secrets, {
     fallbackMode: secretFallbackMode,
-    workspaceState:
-      secretFallbackMode === 'workspace-state' ? context.workspaceState : undefined,
+    workspaceState: secretFallbackMode === 'workspace-state' ? context.workspaceState : undefined,
     machineId: vscode.env.machineId,
     logger,
     onFallbackEngaged: (mode, reason) => {
@@ -125,15 +124,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     })
   );
   const schemaService = new SchemaService(fmClient, logger, {
-    getCacheTtlMs: () =>
-      normalizeSchemaCacheTtlMs(settingsService.getSchemaCacheTtlSeconds()),
+    getCacheTtlMs: () => normalizeSchemaCacheTtlMs(settingsService.getSchemaCacheTtlSeconds()),
     isMetadataEnabled: () => settingsService.isSchemaMetadataEnabled(),
     offlineModeService
   });
   const environmentCompareService = new EnvironmentCompareService(fmClient, schemaService, logger);
   const snapshotStore = new SchemaSnapshotStore(context.workspaceState, logger, {
-    getStorageMode: () =>
-      settingsService.getSchemaSnapshotsStorage(),
+    getStorageMode: () => settingsService.getSchemaSnapshotsStorage(),
     getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     isWorkspaceTrusted: () => vscode.workspace.isTrusted
   });
@@ -338,7 +335,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const jobsSubscription = jobRunner.onDidChange(() => {
     refreshExplorer();
-    const running = jobRunner.listJobs().find((job) => job.status === 'running' || job.status === 'queued');
+    const running = jobRunner
+      .listJobs()
+      .find((job) => job.status === 'running' || job.status === 'queued');
     if (!running) {
       jobsStatusBar.text = '$(history) FM Jobs: idle';
       return;
@@ -445,37 +444,153 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   registerWalkthroughCommands(context, logger);
+  void maybeOpenWhatsNewAfterUpgrade(context, logger);
   void maybeOpenFirstRunWalkthrough(context, logger);
 
   logger.info('FileMaker Data API Tools activated.');
 }
 
-const WALKTHROUGH_STEP_ID = 'filemakerGettingStarted';
+const GETTING_STARTED_WALKTHROUGH_ID = 'filemakerGettingStarted';
 const FIRST_RUN_FLAG = 'filemaker.walkthrough.shownOnce';
+export const WHATS_NEW_LAST_SEEN_VERSION_KEY = 'filemaker.whatsNew.lastSeenVersion';
+const WHATS_NEW_BASELINE_VERSION = '1.1.0';
+
+interface WhatsNewRelease {
+  readonly version: string;
+  readonly walkthroughId: string;
+  readonly title: string;
+  readonly highlights: readonly string[];
+}
+
+const WHATS_NEW_RELEASES: readonly WhatsNewRelease[] = [
+  {
+    version: '1.1.0',
+    walkthroughId: 'filemakerWhatsNew110',
+    title: "What's New in v1.1.0",
+    highlights: [
+      'Guided first-run onboarding',
+      'Persistent connection status',
+      'Query Builder discoverability',
+      'Resilient Data API sessions'
+    ]
+  },
+  {
+    version: '1.2.0',
+    walkthroughId: 'filemakerWhatsNew120',
+    title: "What's New in v1.2.0",
+    highlights: [
+      'FM Web project scaffolding',
+      'Layout Mode authoring',
+      'Schema and batch workflow improvements',
+      'Post-upgrade release visibility'
+    ]
+  }
+];
 
 /**
  * The fully qualified walkthrough id must match `publisher.name#stepId` exactly.
  * Computing it from context.extension.id at runtime avoids a silent break if
  * package.json publisher/name ever change (typo fix, fork, ownership transfer).
  */
-function walkthroughId(context: vscode.ExtensionContext): string {
-  return `${context.extension.id}#${WALKTHROUGH_STEP_ID}`;
+function walkthroughId(context: vscode.ExtensionContext, id: string): string {
+  return `${context.extension.id}#${id}`;
 }
 
-function registerWalkthroughCommands(
+async function openContributedWalkthrough(
+  context: vscode.ExtensionContext,
+  id: string
+): Promise<void> {
+  await vscode.commands.executeCommand(
+    'workbench.action.openWalkthrough',
+    walkthroughId(context, id),
+    false
+  );
+}
+
+export function compareExtensionVersions(left: string, right: string): number {
+  const parse = (version: string): { parts: [number, number, number]; prerelease?: string } => {
+    const trimmed = version.trim();
+    const [core = '0.0.0', prerelease] = trimmed.split('-', 2);
+    const rawParts = core.split('.');
+    const numberAt = (index: number): number => {
+      const value = Number.parseInt(rawParts[index] ?? '0', 10);
+      return Number.isFinite(value) ? value : 0;
+    };
+    return {
+      parts: [numberAt(0), numberAt(1), numberAt(2)],
+      prerelease
+    };
+  };
+
+  const leftVersion = parse(left);
+  const rightVersion = parse(right);
+  const pairs: Array<[number, number]> = [
+    [leftVersion.parts[0], rightVersion.parts[0]],
+    [leftVersion.parts[1], rightVersion.parts[1]],
+    [leftVersion.parts[2], rightVersion.parts[2]]
+  ];
+  for (const [leftPart, rightPart] of pairs) {
+    const delta = leftPart - rightPart;
+    if (delta !== 0) {
+      return delta > 0 ? 1 : -1;
+    }
+  }
+
+  if (leftVersion.prerelease && !rightVersion.prerelease) {
+    return -1;
+  }
+  if (!leftVersion.prerelease && rightVersion.prerelease) {
+    return 1;
+  }
+  if (leftVersion.prerelease && rightVersion.prerelease) {
+    return leftVersion.prerelease.localeCompare(rightVersion.prerelease);
+  }
+  return 0;
+}
+
+function currentExtensionVersion(context: vscode.ExtensionContext): string {
+  const packageJson = context.extension.packageJSON as { version?: unknown };
+  return typeof packageJson.version === 'string' && packageJson.version.trim().length > 0
+    ? packageJson.version.trim()
+    : '0.0.0';
+}
+
+function latestWhatsNewReleaseFor(version: string): WhatsNewRelease | undefined {
+  return WHATS_NEW_RELEASES.filter(
+    (release) => compareExtensionVersions(release.version, version) <= 0
+  ).sort((left, right) => compareExtensionVersions(right.version, left.version))[0];
+}
+
+export function registerWalkthroughCommands(
   context: vscode.ExtensionContext,
   logger: { warn: (message: string, meta?: unknown) => void }
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('filemakerDataApiTools.openWelcomeWalkthrough', async () => {
       try {
-        await vscode.commands.executeCommand(
-          'workbench.action.openWalkthrough',
-          { category: walkthroughId(context) },
-          false
-        );
+        await openContributedWalkthrough(context, GETTING_STARTED_WALKTHROUGH_ID);
       } catch (error) {
         logger.warn('Failed to open getting-started walkthrough.', { error });
+      }
+    }),
+    vscode.commands.registerCommand('filemakerDataApiTools.showWhatsNew', async () => {
+      const release = latestWhatsNewReleaseFor(currentExtensionVersion(context));
+      if (!release) {
+        void vscode.window.showInformationMessage(
+          "FileMaker: No What's New walkthrough is available for this version."
+        );
+        return;
+      }
+
+      try {
+        await openContributedWalkthrough(context, release.walkthroughId);
+      } catch (error) {
+        logger.warn("Failed to open What's New walkthrough.", {
+          error,
+          title: release.title,
+          version: release.version,
+          highlights: release.highlights
+        });
       }
     }),
     vscode.commands.registerCommand('filemakerDataApiTools.openUserGuide', async () => {
@@ -490,19 +605,65 @@ function registerWalkthroughCommands(
   );
 }
 
+export async function maybeOpenWhatsNewAfterUpgrade(
+  context: vscode.ExtensionContext,
+  logger: {
+    info: (message: string, meta?: unknown) => void;
+    warn: (message: string, meta?: unknown) => void;
+  }
+): Promise<void> {
+  try {
+    const currentVersion = currentExtensionVersion(context);
+    const storedLastSeenVersion = context.globalState.get<string>(WHATS_NEW_LAST_SEEN_VERSION_KEY);
+    const firstRunAlreadyShown = context.globalState.get<boolean>(FIRST_RUN_FLAG, false);
+
+    if (!storedLastSeenVersion && !firstRunAlreadyShown) {
+      await context.globalState.update(WHATS_NEW_LAST_SEEN_VERSION_KEY, currentVersion);
+      return;
+    }
+
+    const lastSeenVersion = storedLastSeenVersion ?? WHATS_NEW_BASELINE_VERSION;
+    if (compareExtensionVersions(currentVersion, lastSeenVersion) <= 0) {
+      if (!storedLastSeenVersion) {
+        await context.globalState.update(WHATS_NEW_LAST_SEEN_VERSION_KEY, currentVersion);
+      }
+      return;
+    }
+
+    const release = latestWhatsNewReleaseFor(currentVersion);
+    if (!release || compareExtensionVersions(release.version, lastSeenVersion) <= 0) {
+      await context.globalState.update(WHATS_NEW_LAST_SEEN_VERSION_KEY, currentVersion);
+      return;
+    }
+
+    await openContributedWalkthrough(context, release.walkthroughId);
+    await context.globalState.update(WHATS_NEW_LAST_SEEN_VERSION_KEY, currentVersion);
+    logger.info("Post-upgrade What's New walkthrough opened.", {
+      currentVersion,
+      lastSeenVersion,
+      release: release.version,
+      title: release.title,
+      highlights: release.highlights
+    });
+  } catch (error) {
+    logger.warn("Post-upgrade What's New walkthrough failed; will retry next activation.", {
+      error
+    });
+  }
+}
+
 async function maybeOpenFirstRunWalkthrough(
   context: vscode.ExtensionContext,
-  logger: { info: (message: string, meta?: unknown) => void; warn: (message: string, meta?: unknown) => void }
+  logger: {
+    info: (message: string, meta?: unknown) => void;
+    warn: (message: string, meta?: unknown) => void;
+  }
 ): Promise<void> {
   if (context.globalState.get<boolean>(FIRST_RUN_FLAG, false)) {
     return;
   }
   try {
-    await vscode.commands.executeCommand(
-      'workbench.action.openWalkthrough',
-      { category: walkthroughId(context) },
-      false
-    );
+    await openContributedWalkthrough(context, GETTING_STARTED_WALKTHROUGH_ID);
     // Only persist the flag AFTER the walkthrough actually opens. A transient
     // failure on day one (host restart, missing markdown asset) used to flip
     // the flag and permanently suppress the walkthrough; the user would never

--- a/extension/test/unit/whatsNew.test.ts
+++ b/extension/test/unit/whatsNew.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+import {
+  WHATS_NEW_LAST_SEEN_VERSION_KEY,
+  compareExtensionVersions,
+  maybeOpenWhatsNewAfterUpgrade,
+  registerWalkthroughCommands
+} from '../../src/extension';
+import { InMemoryMemento } from './mocks';
+
+const FIRST_RUN_FLAG = 'filemaker.walkthrough.shownOnce';
+
+function createContext(version: string) {
+  const globalState = new InMemoryMemento();
+  const context = {
+    subscriptions: [] as vscode.Disposable[],
+    extensionUri: { fsPath: '/test/extension', toString: () => 'file:///test/extension' },
+    globalState,
+    extension: {
+      id: 'deffenda.filemaker-data-api-tools',
+      packageJSON: { version }
+    }
+  } as unknown as vscode.ExtensionContext & { globalState: InMemoryMemento };
+
+  return { context, globalState };
+}
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn()
+  };
+}
+
+describe('compareExtensionVersions', () => {
+  it('orders semantic versions by major, minor, and patch', () => {
+    expect(compareExtensionVersions('1.2.0', '1.1.9')).toBe(1);
+    expect(compareExtensionVersions('1.2.0', '1.2.0')).toBe(0);
+    expect(compareExtensionVersions('1.2.0-beta.1', '1.2.0')).toBe(-1);
+  });
+});
+
+describe('maybeOpenWhatsNewAfterUpgrade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records the current version without opening on fresh install', async () => {
+    const { context, globalState } = createContext('1.2.0');
+
+    await maybeOpenWhatsNewAfterUpgrade(context, createLogger());
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    expect(globalState.get(WHATS_NEW_LAST_SEEN_VERSION_KEY)).toBe('1.2.0');
+  });
+
+  it('opens the matching release walkthrough once after an upgrade', async () => {
+    const { context, globalState } = createContext('1.2.0');
+    await globalState.update(FIRST_RUN_FLAG, true);
+
+    await maybeOpenWhatsNewAfterUpgrade(context, createLogger());
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openWalkthrough',
+      'deffenda.filemaker-data-api-tools#filemakerWhatsNew120',
+      false
+    );
+    expect(globalState.get(WHATS_NEW_LAST_SEEN_VERSION_KEY)).toBe('1.2.0');
+  });
+
+  it('does not reopen when the current version was already seen', async () => {
+    const { context, globalState } = createContext('1.2.0');
+    await globalState.update(FIRST_RUN_FLAG, true);
+    await globalState.update(WHATS_NEW_LAST_SEEN_VERSION_KEY, '1.2.0');
+
+    await maybeOpenWhatsNewAfterUpgrade(context, createLogger());
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerWalkthroughCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers a manual Show What's New command that opens the current walkthrough", async () => {
+    const { context } = createContext('1.2.0');
+    const logger = createLogger();
+
+    registerWalkthroughCommands(context, logger);
+
+    const registration = vi
+      .mocked(vscode.commands.registerCommand)
+      .mock.calls.find(([command]) => command === 'filemakerDataApiTools.showWhatsNew');
+    expect(registration).toBeDefined();
+
+    const handler = registration?.[1] as () => Promise<void>;
+    await handler();
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openWalkthrough',
+      'deffenda.filemaker-data-api-tools#filemakerWhatsNew120',
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a versioned What's New registry and manual `FileMaker: Show What's New` command
- auto-open the matching walkthrough once after an upgrade, then persist the seen extension version
- add v1.1.0 and v1.2.0 walkthrough contributions with screenshot-backed markdown assets
- document the release process for adding future What's New content

Closes #167

## Validation

- `npm run test -w extension -- whatsNew`
- `npm run typecheck -w extension`
- `npm run lint -w extension`
- `npm run lint`
- `npm run test`
- `npm run typecheck`
- `npm run build`
- `npm run build -w extension`
- `npm run package:check`
- `git diff --check`

## Notes

- `npm run format:check` still fails on the existing repo baseline: Prettier reports 121 pre-existing extension files. I did not rewrite unrelated files.
