### PR TITLE
Add headless bridge Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+artifacts
+coverage
+dist
+docs/api
+node_modules
+**/coverage
+**/dist
+**/node_modules
+*.vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           # number, with a one-line rationale in the commit message
           # (e.g., "raising to 5 MB to accommodate webview chunk split").
           # See docs/BUNDLE_SIZE.md for the policy.
-          VSIX_BUDGET_BYTES: '5242880'  # 5 MiB
+          VSIX_BUDGET_BYTES: '5242880' # 5 MiB
         run: |
           VSIX_PATH="$(echo artifacts/*.vsix)"
           if [ ! -f "$VSIX_PATH" ]; then
@@ -63,6 +63,15 @@ jobs:
             echo "::error::VSIX exceeds the size budget. See docs/BUNDLE_SIZE.md for how to raise the cap intentionally vs. trim the bundle."
             exit 1
           fi
+
+  headless-bridge-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and smoke-test headless bridge image
+        run: scripts/smoke-headless-bridge-image.sh filemaker-bridge:ci
 
   package:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -129,3 +138,42 @@ jobs:
                 --notes-file -
         env:
           GH_TOKEN: ${{ github.token }}
+
+  publish-headless-bridge-image:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build-test
+      - headless-bridge-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/abd-enterprises/filemaker-bridge
+          tags: |
+            type=ref,event=tag
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY extension/package.json extension/package.json
+COPY shared/package.json shared/package.json
+COPY designer-ui/package.json designer-ui/package.json
+COPY runtime-next/package.json runtime-next/package.json
+RUN npm ci --workspaces --include-workspace-root
+
+FROM deps AS build
+COPY extension extension
+RUN npm run build:headless-bridge -w extension
+
+FROM node:20-bookworm-slim AS runtime
+ENV NODE_ENV=production
+ENV BRIDGE_PORT=8080
+WORKDIR /app
+
+COPY --from=build /app/extension/dist/headlessBridge.js ./extension/dist/headlessBridge.js
+
+RUN mkdir -p /run/secrets
+USER node
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:' + (process.env.BRIDGE_PORT || '8080') + '/healthz').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+CMD ["node", "extension/dist/headlessBridge.js"]

--- a/docs/HEADLESS_BRIDGE.md
+++ b/docs/HEADLESS_BRIDGE.md
@@ -1,0 +1,76 @@
+# Headless FileMaker Bridge
+
+The headless bridge image runs the embedded `fmBridgeServer` without VS Code. Use it when automation needs the same bridge routes from CI pipelines, scheduled jobs, or a controlled gateway service between FileMaker and other tools.
+
+The release image is published to:
+
+```text
+ghcr.io/abd-enterprises/filemaker-bridge
+```
+
+## Configuration
+
+The container reads FileMaker connection settings from environment variables:
+
+| Variable       | Required | Description                                                                                   |
+| -------------- | -------: | --------------------------------------------------------------------------------------------- |
+| `BRIDGE_PORT`  |       No | HTTP port inside the container. Defaults to `8080`.                                           |
+| `FM_SERVER`    |      Yes | FileMaker Server or FileMaker Cloud base URL, such as `https://fm.example.com`.               |
+| `FM_DATABASE`  |      Yes | Database name used for Data API requests.                                                     |
+| `FM_USER`      |      Yes | Direct Data API username.                                                                     |
+| `FM_PASS_FILE` |      Yes | Path to a mounted file containing the FileMaker password.                                     |
+| `BRIDGE_TOKEN` |       No | Stable token for bridge clients. If omitted, the bridge generates one and logs it at startup. |
+
+Use a mounted secret for `FM_PASS_FILE`; do not pass the FileMaker password as a plain environment variable.
+
+## Run Locally
+
+```bash
+docker run --rm \
+  -p 8080:8080 \
+  -e BRIDGE_PORT=8080 \
+  -e BRIDGE_TOKEN="$(openssl rand -hex 32)" \
+  -e FM_SERVER=https://fm.example.com \
+  -e FM_DATABASE=Operations \
+  -e FM_USER=automation \
+  -e FM_PASS_FILE=/run/secrets/fm-password \
+  -v "$PWD/.secrets/fm-password:/run/secrets/fm-password:ro" \
+  ghcr.io/abd-enterprises/filemaker-bridge:v1.1.0
+```
+
+Check startup:
+
+```bash
+curl -fsS http://127.0.0.1:8080/healthz
+```
+
+Run a script through the bridge:
+
+```bash
+curl -fsS http://127.0.0.1:8080/fm/runScript \
+  -H "Content-Type: application/json" \
+  -H "X-FM-Bridge-Token: $BRIDGE_TOKEN" \
+  --data '{"layout":"Jobs","scriptName":"Run_Scheduled_Job","scriptParam":"nightly"}'
+```
+
+## CI Pipelines
+
+CI jobs can start the container as a service, mount the FileMaker password from the CI secret store, and call `/fm/runScript` or CRUD routes to seed data, validate migrations, or run acceptance scripts.
+
+## Scheduled Jobs
+
+Schedulers such as cron, GitHub Actions schedules, or Kubernetes CronJobs can run the image on a private network and execute a FileMaker script with a short-lived `BRIDGE_TOKEN`.
+
+## Gateway Use
+
+When a central automation host needs to broker FileMaker Data API access for other trusted internal tools, run the bridge behind private networking or a reverse proxy that enforces TLS and upstream authentication. The bridge token is still required on every `/fm/*` request.
+
+## Validation
+
+Build and smoke-test the image locally:
+
+```bash
+scripts/smoke-headless-bridge-image.sh
+```
+
+The smoke test builds the Docker image, starts it with a mounted password file and fake FileMaker connection settings, then verifies the `/healthz` endpoint.

--- a/docs/ci-baseline.md
+++ b/docs/ci-baseline.md
@@ -8,13 +8,16 @@ for re-introducing a custom guardrail.
 
 Branch protection on `main` enforces two contexts:
 
-| Context | Source | What it covers |
-|---|---|---|
+| Context      | Source                     | What it covers                                                                                                           |
+| ------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `build-test` | `.github/workflows/ci.yml` | `npm install`, `npm audit --omit=dev --audit-level=high`, `lint`, `typecheck`, `test:coverage`, `build`, `package:check` |
-| `CodeQL`     | GitHub default setup | Code scanning for `actions`, `javascript`, `javascript-typescript`, `typescript` |
+| `CodeQL`     | GitHub default setup       | Code scanning for `actions`, `javascript`, `javascript-typescript`, `typescript`                                         |
 
 Together these are the minimum bar a change must clear before it can land
 on `main`.
+
+Release-tag builds also publish the headless FileMaker bridge image to GHCR
+after the Docker image smoke test passes.
 
 ## What `build-test` actually runs
 
@@ -28,6 +31,12 @@ and `npm run package:check` reproduce it.
 - **Tests** — `vitest run --coverage` in each workspace that ships a test script
 - **Build** — `esbuild` bundle of the extension entry point + webview asset copy
 - **Package check** — `vsce package` to ensure the extension is publishable
+
+## Headless bridge image
+
+The `headless-bridge-image` job builds the standalone bridge Docker image and
+smoke-tests its `/healthz` endpoint. On release tags, `publish-headless-bridge-image`
+pushes the same image to `ghcr.io/abd-enterprises/filemaker-bridge`.
 
 ## What was removed and why
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -896,9 +896,11 @@
   "scripts": {
     "clean": "rimraf dist",
     "bundle:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap=inline --outfile=dist/extension.js",
+    "bundle:headless-bridge": "esbuild src/headlessBridge.ts --bundle --platform=node --format=cjs --sourcemap=inline --outfile=dist/headlessBridge.js",
     "build:designer-ui": "node ./scripts/build-designer-ui-if-available.mjs",
     "copy:webviews": "shx mkdir -p dist/webviews/queryBuilder/ui dist/webviews/recordViewer/ui dist/webviews/scriptRunner/ui dist/webviews/schemaDiff/ui dist/webviews/recordEditor/ui dist/webviews/connectionWizard/ui dist/webviews/layoutMode/ui && shx cp -r src/webviews/queryBuilder/ui/* dist/webviews/queryBuilder/ui && shx cp -r src/webviews/recordViewer/ui/* dist/webviews/recordViewer/ui && shx cp -r src/webviews/scriptRunner/ui/* dist/webviews/scriptRunner/ui && shx cp -r src/webviews/schemaDiff/ui/* dist/webviews/schemaDiff/ui && shx cp -r src/webviews/recordEditor/ui/* dist/webviews/recordEditor/ui && shx cp -r src/webviews/connectionWizard/ui/* dist/webviews/connectionWizard/ui && shx cp -r src/webviews/layoutMode/ui/* dist/webviews/layoutMode/ui && sh -c 'if [ -d ../designer-ui/dist ]; then shx cp -r ../designer-ui/dist/* dist/webviews/layoutMode/ui; fi'",
     "build": "npm run build:designer-ui && npm run clean && npm run bundle:extension && npm run copy:webviews",
+    "build:headless-bridge": "npm run clean && npm run bundle:headless-bridge",
     "watch": "tsc -w -p .",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --max-warnings=0",
     "format": "prettier --write \"**/*.{ts,js,json,md,css,html}\"",

--- a/extension/src/headlessBridge.ts
+++ b/extension/src/headlessBridge.ts
@@ -1,0 +1,243 @@
+import { readFile } from 'fs/promises';
+
+import type * as vscode from 'vscode';
+
+import { FMClient } from './services/fmClient';
+import { FmBridgeServer } from './services/fmBridgeServer';
+import { SecretStore } from './services/secretStore';
+import type { FmWebProjectService } from './services/fmWebProjectService';
+import type { Logger } from './services/logger';
+import type { ProfileStore } from './services/profileStore';
+import type { ConnectionProfile } from './types/fm';
+
+const HEADLESS_PROFILE_ID = 'headless-env';
+const DEFAULT_BRIDGE_PORT = 8080;
+const BRIDGE_HOST = '0.0.0.0';
+
+export interface HeadlessBridgeConfig {
+  port: number;
+  serverUrl: string;
+  database: string;
+  username: string;
+  passwordFile: string;
+  bridgeToken?: string;
+}
+
+export interface StartedHeadlessBridge {
+  port: number;
+  baseUrl: string;
+  bridgeToken: string;
+  stop: () => Promise<void>;
+}
+
+export function resolveHeadlessBridgeConfig(env: NodeJS.ProcessEnv): HeadlessBridgeConfig {
+  return {
+    port: parseBridgePort(env.BRIDGE_PORT),
+    serverUrl: normalizeServerUrl(readRequiredEnv(env, 'FM_SERVER')),
+    database: readRequiredEnv(env, 'FM_DATABASE'),
+    username: readRequiredEnv(env, 'FM_USER'),
+    passwordFile: readRequiredEnv(env, 'FM_PASS_FILE'),
+    bridgeToken: readOptionalEnv(env, 'BRIDGE_TOKEN')
+  };
+}
+
+export async function startHeadlessBridgeFromEnv(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<StartedHeadlessBridge> {
+  const config = resolveHeadlessBridgeConfig(env);
+  const password = await readPasswordFile(config.passwordFile);
+  const logger = createConsoleLogger();
+  const secrets = createMemorySecretStorage();
+  const secretStore = new SecretStore(secrets);
+  const profile = createHeadlessProfile(config);
+  const profileStore = createHeadlessProfileStore(profile);
+  const fmClient = new FMClient(secretStore, logger);
+  const projectService = createHeadlessProjectService(profile.id);
+
+  await secretStore.setPassword(profile.id, password);
+
+  const bridgeServer = new FmBridgeServer(profileStore, fmClient, projectService, logger, {
+    host: BRIDGE_HOST,
+    port: config.port,
+    allowRemoteClients: true,
+    sessionToken: config.bridgeToken
+  });
+  const started = await bridgeServer.ensureStarted();
+  const bridgeToken = bridgeServer.getSessionToken();
+  if (!bridgeToken) {
+    throw new Error('Headless bridge started without a session token.');
+  }
+
+  logger.info('Headless FileMaker bridge started.', {
+    port: started.port,
+    baseUrl: started.baseUrl,
+    tokenSource: config.bridgeToken ? 'BRIDGE_TOKEN' : 'generated'
+  });
+
+  if (!config.bridgeToken) {
+    logger.info('Generated bridge token for this process.', {
+      bridgeToken
+    });
+  }
+
+  return {
+    port: started.port,
+    baseUrl: started.baseUrl,
+    bridgeToken,
+    stop: () => bridgeServer.stop()
+  };
+}
+
+function parseBridgePort(rawPort: string | undefined): number {
+  const value = rawPort?.trim() || String(DEFAULT_BRIDGE_PORT);
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error('BRIDGE_PORT must be an integer from 1 to 65535.');
+  }
+
+  return port;
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = readOptionalEnv(env, name);
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+
+  return value;
+}
+
+function readOptionalEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = env[name]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function normalizeServerUrl(rawServerUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawServerUrl);
+  } catch {
+    throw new Error('FM_SERVER must be a valid http(s) URL.');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('FM_SERVER must use http or https.');
+  }
+
+  return rawServerUrl.replace(/\/+$/, '');
+}
+
+async function readPasswordFile(passwordFile: string): Promise<string> {
+  const password = (await readFile(passwordFile, 'utf8')).replace(/\r?\n$/, '');
+  if (!password) {
+    throw new Error('FM_PASS_FILE must point to a non-empty password file.');
+  }
+
+  return password;
+}
+
+function createHeadlessProfile(config: HeadlessBridgeConfig): ConnectionProfile {
+  return {
+    id: HEADLESS_PROFILE_ID,
+    name: 'Headless bridge',
+    serverUrl: config.serverUrl,
+    database: config.database,
+    authMode: 'direct',
+    username: config.username
+  };
+}
+
+function createHeadlessProfileStore(profile: ConnectionProfile): ProfileStore {
+  const store = {
+    getActiveProfileId: () => profile.id,
+    getProfile: async (profileId: string) => (profileId === profile.id ? profile : undefined)
+  };
+
+  return store as unknown as ProfileStore;
+}
+
+function createHeadlessProjectService(profileId: string): FmWebProjectService {
+  const service = {
+    isWorkspaceTrusted: () => true,
+    readProjectConfig: async () => ({
+      activeProfileId: profileId
+    })
+  };
+
+  return service as unknown as FmWebProjectService;
+}
+
+function createMemorySecretStorage(): vscode.SecretStorage {
+  const values = new Map<string, string>();
+  const secrets = {
+    get: async (key: string) => values.get(key),
+    store: async (key: string, value: string) => {
+      values.set(key, value);
+    },
+    delete: async (key: string) => {
+      values.delete(key);
+    }
+  };
+
+  return secrets as unknown as vscode.SecretStorage;
+}
+
+function createConsoleLogger(): Pick<Logger, 'debug' | 'info' | 'warn' | 'error'> {
+  return {
+    debug: (message: string, metadata?: unknown) => log('debug', message, metadata),
+    info: (message: string, metadata?: unknown) => log('info', message, metadata),
+    warn: (message: string, metadata?: unknown) => log('warn', message, metadata),
+    error: (message: string, metadata?: unknown) => log('error', message, metadata)
+  };
+}
+
+function log(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  metadata?: unknown
+): void {
+  const entry = {
+    level,
+    message,
+    ...(metadata && typeof metadata === 'object' ? { metadata } : {})
+  };
+  const rendered = JSON.stringify(entry);
+  if (level === 'error') {
+    console.error(rendered);
+    return;
+  }
+  if (level === 'warn') {
+    console.warn(rendered);
+    return;
+  }
+  console.log(rendered);
+}
+
+if (require.main === module) {
+  let startedBridge: StartedHeadlessBridge | undefined;
+
+  const stop = async (): Promise<void> => {
+    if (!startedBridge) {
+      return;
+    }
+    await startedBridge.stop();
+    startedBridge = undefined;
+  };
+
+  startHeadlessBridgeFromEnv()
+    .then((started) => {
+      startedBridge = started;
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Failed to start headless bridge.';
+      console.error(JSON.stringify({ level: 'error', message }));
+      process.exit(1);
+    });
+
+  process.on('SIGINT', () => {
+    void stop().finally(() => process.exit(0));
+  });
+  process.on('SIGTERM', () => {
+    void stop().finally(() => process.exit(0));
+  });
+}

--- a/extension/src/services/fmBridgeServer.ts
+++ b/extension/src/services/fmBridgeServer.ts
@@ -19,6 +19,17 @@ const DEFAULT_ROUTE_TIMEOUT_MS = 20_000;
 export interface FmBridgeServerOptions {
   /** Resolved at request time so settings updates flow live. */
   getRateLimitConfig?: () => BridgeRateLimitConfig;
+  /** Host/interface to bind. Defaults to localhost for the embedded VS Code bridge. */
+  host?: string;
+  /** Port to bind. Defaults to 0 so the OS assigns an ephemeral localhost port. */
+  port?: number;
+  /**
+   * Permit non-local clients. Keep false for the embedded bridge; Docker/headless mode
+   * enables this explicitly and still requires the bridge token.
+   */
+  allowRemoteClients?: boolean;
+  /** Fixed token for automation clients. Defaults to a generated per-process token. */
+  sessionToken?: string;
 }
 
 export class FmBridgeServer {
@@ -54,7 +65,7 @@ export class FmBridgeServer {
 
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject);
-      server.listen(0, '127.0.0.1', () => {
+      server.listen(this.options.port ?? 0, this.options.host ?? '127.0.0.1', () => {
         resolve();
       });
     });
@@ -67,7 +78,7 @@ export class FmBridgeServer {
 
     this.server = server;
     this.port = address.port;
-    this.sessionToken = randomBytes(32).toString('hex');
+    this.sessionToken = this.options.sessionToken ?? randomBytes(32).toString('hex');
     const rateConfig = this.options.getRateLimitConfig?.() ?? DEFAULT_BRIDGE_RATE_LIMIT;
     this.rateLimiter = new BridgeRateLimiter(rateConfig);
     this.rateLimitWarningEmitted = false;
@@ -130,8 +141,13 @@ export class FmBridgeServer {
         return;
       }
 
-      if (!isLocalSocket(request.socket.remoteAddress)) {
+      if (!this.options.allowRemoteClients && !isLocalSocket(request.socket.remoteAddress)) {
         this.sendJson(response, 403, { error: 'Bridge server only accepts localhost clients.' });
+        return;
+      }
+
+      if (request.method === 'GET' && getHealthPath(request.url)) {
+        this.sendJson(response, 200, { status: 'ok' });
         return;
       }
 
@@ -233,7 +249,9 @@ export class FmBridgeServer {
 
         const request: FindRecordsRequest = {
           query: query as Array<Record<string, unknown>>,
-          sort: Array.isArray(payload.sort) ? (payload.sort as Array<Record<string, unknown>>) : undefined,
+          sort: Array.isArray(payload.sort)
+            ? (payload.sort as Array<Record<string, unknown>>)
+            : undefined,
           limit: parseOptionalNumber(payload.limit),
           offset: parseOptionalNumber(payload.offset)
         };
@@ -308,9 +326,7 @@ export class FmBridgeServer {
   private async resolveProfile(profileIdFromRequest?: string) {
     const project = await this.fmWebProjectService.readProjectConfig();
     const profileId =
-      profileIdFromRequest ??
-      project?.activeProfileId ??
-      this.profileStore.getActiveProfileId();
+      profileIdFromRequest ?? project?.activeProfileId ?? this.profileStore.getActiveProfileId();
 
     if (!profileId) {
       return undefined;
@@ -378,7 +394,9 @@ function isLocalSocket(remoteAddress: string | undefined): boolean {
     return false;
   }
 
-  return remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1';
+  return (
+    remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1'
+  );
 }
 
 function isAllowedOrigin(origin: string): boolean {
@@ -405,6 +423,15 @@ function getRoutePath(rawUrl: string | undefined): string | undefined {
   }
 
   return parsed.pathname.slice(3);
+}
+
+function getHealthPath(rawUrl: string | undefined): boolean {
+  if (!rawUrl) {
+    return false;
+  }
+
+  const parsed = new URL(rawUrl, 'http://127.0.0.1');
+  return parsed.pathname === '/healthz';
 }
 
 function readHeader(value: string | string[] | undefined): string | undefined {

--- a/extension/test/unit/fmBridgeServer.test.ts
+++ b/extension/test/unit/fmBridgeServer.test.ts
@@ -70,9 +70,68 @@ describe('FmBridgeServer', () => {
     expect(body.error).toContain('Origin');
   });
 
+  it('serves health checks without bridge token authentication', async () => {
+    const server = new FmBridgeServer(
+      createProfileStoreStub(),
+      createFmClientStub(),
+      createFmWebProjectServiceStub(),
+      logger
+    );
+
+    const response = await invokeBridgeRequest(server, '/healthz', {
+      method: 'GET'
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.json).toEqual({ status: 'ok' });
+  });
+
+  it('permits remote clients only when explicitly configured', async () => {
+    const defaultServer = new FmBridgeServer(
+      createProfileStoreStub(),
+      createFmClientStub(),
+      createFmWebProjectServiceStub(),
+      logger
+    );
+
+    const defaultResponse = await invokeBridgeRequest(defaultServer, '/fm/find', {
+      remoteAddress: '172.17.0.1',
+      payload: {
+        layout: 'Contacts',
+        query: [{}]
+      }
+    });
+
+    const headlessServer = new FmBridgeServer(
+      createProfileStoreStub(),
+      createFmClientStub(),
+      createFmWebProjectServiceStub(),
+      logger,
+      {
+        allowRemoteClients: true
+      }
+    );
+
+    const headlessResponse = await invokeBridgeRequest(headlessServer, '/fm/find', {
+      remoteAddress: '172.17.0.1',
+      payload: {
+        layout: 'Contacts',
+        query: [{}]
+      }
+    });
+
+    expect(defaultResponse.status).toBe(403);
+    expect(headlessResponse.status).toBe(200);
+  });
+
   it('returns timeout/abort failures from route handlers', async () => {
     const findRecords = vi.fn(
-      async (_profile: ConnectionProfile, _layout: string, _request: unknown, control?: { signal?: AbortSignal }) =>
+      async (
+        _profile: ConnectionProfile,
+        _layout: string,
+        _request: unknown,
+        control?: { signal?: AbortSignal }
+      ) =>
         new Promise<FindRecordsResult>((_resolve, reject) => {
           control?.signal?.addEventListener('abort', () => reject(new Error('Request timed out.')));
         })
@@ -107,12 +166,19 @@ async function invokeBridgeRequest(
   server: FmBridgeServer,
   route: string,
   input: {
+    method?: string;
     origin?: string;
     payload?: Record<string, unknown>;
     remoteAddress?: string;
   }
 ): Promise<{ status: number; body: string; json: unknown; headers: Record<string, string> }> {
-  const request = buildRequest(route, input.origin, input.payload, input.remoteAddress);
+  const request = buildRequest(
+    route,
+    input.method,
+    input.origin,
+    input.payload,
+    input.remoteAddress
+  );
   const response = buildResponse();
 
   const bridge = server as unknown as {
@@ -135,6 +201,7 @@ async function invokeBridgeRequest(
 
 function buildRequest(
   route: string,
+  method: string | undefined,
   origin: string | undefined,
   payload: Record<string, unknown> | undefined,
   remoteAddress = '127.0.0.1'
@@ -143,7 +210,7 @@ function buildRequest(
     read() {}
   }) as IncomingMessage;
 
-  readable.method = 'POST';
+  readable.method = method ?? 'POST';
   readable.url = route;
   readable.headers = {
     'content-type': 'application/json',

--- a/extension/test/unit/headlessBridge.test.ts
+++ b/extension/test/unit/headlessBridge.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHeadlessBridgeConfig } from '../../src/headlessBridge';
+
+describe('headless bridge config', () => {
+  it('reads required env configuration and defaults the bridge port', () => {
+    const config = resolveHeadlessBridgeConfig({
+      FM_SERVER: 'https://fm.example.com/',
+      FM_DATABASE: 'Operations',
+      FM_USER: 'automation',
+      FM_PASS_FILE: '/run/secrets/fm-password'
+    });
+
+    expect(config).toEqual({
+      port: 8080,
+      serverUrl: 'https://fm.example.com',
+      database: 'Operations',
+      username: 'automation',
+      passwordFile: '/run/secrets/fm-password',
+      bridgeToken: undefined
+    });
+  });
+
+  it('rejects invalid bridge ports', () => {
+    expect(() =>
+      resolveHeadlessBridgeConfig({
+        BRIDGE_PORT: '99999',
+        FM_SERVER: 'https://fm.example.com',
+        FM_DATABASE: 'Operations',
+        FM_USER: 'automation',
+        FM_PASS_FILE: '/run/secrets/fm-password'
+      })
+    ).toThrow('BRIDGE_PORT');
+  });
+
+  it('requires FileMaker connection settings', () => {
+    expect(() => resolveHeadlessBridgeConfig({})).toThrow('FM_SERVER is required');
+  });
+});

--- a/scripts/smoke-headless-bridge-image.sh
+++ b/scripts/smoke-headless-bridge-image.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${1:-filemaker-bridge:smoke}"
+CONTAINER_ID=""
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  if [[ -n "$CONTAINER_ID" ]]; then
+    docker rm -f "$CONTAINER_ID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+printf 'smoke-password\n' >"$TMP_DIR/fm-password"
+chmod 755 "$TMP_DIR"
+chmod 0444 "$TMP_DIR/fm-password"
+
+docker build -t "$IMAGE" "$ROOT"
+
+CONTAINER_ID="$(
+  docker run -d --rm \
+    -e BRIDGE_PORT=8080 \
+    -e BRIDGE_TOKEN=smoke-token \
+    -e FM_SERVER=https://filemaker.example.test \
+    -e FM_DATABASE=SmokeDB \
+    -e FM_USER=smoke-user \
+    -e FM_PASS_FILE=/run/secrets/fm-password \
+    -v "$TMP_DIR/fm-password:/run/secrets/fm-password:ro" \
+    -p 127.0.0.1::8080 \
+    "$IMAGE"
+)"
+
+HOST_PORT="$(docker port "$CONTAINER_ID" 8080/tcp | sed 's/.*://')"
+
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${HOST_PORT}/healthz" >/dev/null; then
+    echo "Headless bridge image smoke test passed."
+    exit 0
+  fi
+  sleep 1
+done
+
+docker logs "$CONTAINER_ID" >&2 || true
+echo "Headless bridge image smoke test failed." >&2
+exit 1


### PR DESCRIPTION
Closes #185.

## Summary
- Add a standalone headless bridge entry point that reads BRIDGE_PORT, FM_SERVER, FM_DATABASE, FM_USER, FM_PASS_FILE, and optional BRIDGE_TOKEN.
- Add a minimal Dockerfile for ghcr.io/abd-enterprises/filemaker-bridge with health checks and a smoke-test script.
- Wire CI to build/smoke-test the image on PRs and publish to GHCR on release tags.
- Document CI, scheduled job, and gateway use cases in docs/HEADLESS_BRIDGE.md.

## Validation
- npm run typecheck
- npm run lint
- npm test -w extension -- --run test/unit/headlessBridge.test.ts test/unit/fmBridgeServer.test.ts
- npm run build:headless-bridge -w extension
- scripts/smoke-headless-bridge-image.sh filemaker-bridge:local-185
- npm audit --omit=dev --audit-level=high
- npm run test:coverage
- npm run build
- npm run package:check
- VSIX size check: 2367645 bytes <= 5242880 bytes
