### PR TITLE
[minor] FileMaker WebDirect URL helper (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ PR title prefix matches the highest-tier label added:
 
 ### [FEATURE]
 
-- None.
+- Added a WebDirect URL helper command that copies the current record URL and can open it in the system browser.
 
 ### [FIX]
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added **FileMaker: Copy WebDirect URL for Current Record** to copy a selected record's WebDirect URL and optionally open it in the system browser.
+
 - Attributed the extension to ABD Enterprises in README and `package.json`:
   - new `author` field pointing at `https://abdenterprises.com`
   - `homepage` now resolves to `abdenterprises.com?ref=vscode` (with the GitHub repo still linked via `repository`)

--- a/extension/package.json
+++ b/extension/package.json
@@ -188,6 +188,10 @@
         "title": "FileMaker: Get Record by ID"
       },
       {
+        "command": "filemakerDataApiTools.copyWebDirectUrlForCurrentRecord",
+        "title": "FileMaker: Copy WebDirect URL for Current Record"
+      },
+      {
         "command": "filemakerDataApiTools.openRecordViewer",
         "title": "FileMaker: Open Record Viewer (by ID)"
       },
@@ -440,6 +444,11 @@
           "group": "navigation@1"
         },
         {
+          "command": "filemakerDataApiTools.copyWebDirectUrlForCurrentRecord",
+          "when": "view == filemakerExplorer && viewItem == fmRecord",
+          "group": "inline@1"
+        },
+        {
           "command": "filemakerDataApiTools.runSavedQuery",
           "when": "view == filemakerExplorer && viewItem == fmSavedQuery",
           "group": "inline@1"
@@ -566,6 +575,7 @@
         { "command": "filemakerDataApiTools.openRecordEditor", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.runFindJson", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.getRecordById", "when": "filemaker.hasProfiles" },
+        { "command": "filemakerDataApiTools.copyWebDirectUrlForCurrentRecord", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.editRecordById", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.createRecord", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.deleteRecord", "when": "filemaker.hasProfiles" },
@@ -655,6 +665,11 @@
           "type": "string",
           "default": "vLatest",
           "description": "Default FileMaker Data API version segment used when a profile does not override it. Replaces the deprecated `filemakerDataApiTools.defaultApiVersionPath`."
+        },
+        "filemaker.webDirect.basePath": {
+          "type": "string",
+          "default": "/fmi/webd",
+          "description": "Base path used when building WebDirect record URLs."
         },
         "filemaker.savedQueries.scope": {
           "type": "string",

--- a/extension/src/commands/common.ts
+++ b/extension/src/commands/common.ts
@@ -14,6 +14,13 @@ export interface LayoutCommandArg extends ProfileCommandArg {
   layoutName?: string;
 }
 
+export interface RecordCommandArg extends LayoutCommandArg {
+  recordId?: string | number;
+  record?: {
+    recordId?: string | number;
+  };
+}
+
 export interface SavedQueryCommandArg extends ProfileCommandArg {
   queryId?: string;
   savedQueryId?: string;
@@ -118,6 +125,27 @@ export function parseLayoutArg(arg: unknown): LayoutCommandArg {
   return {
     profileId: typeof value.profileId === 'string' ? value.profileId : undefined,
     layout: resolvedLayout
+  };
+}
+
+export function parseRecordArg(arg: unknown): LayoutCommandArg & { recordId?: string } {
+  const layoutArg = parseLayoutArg(arg);
+  if (!arg || typeof arg !== 'object') {
+    return layoutArg;
+  }
+
+  const value = arg as RecordCommandArg;
+  const rawRecordId =
+    typeof value.recordId === 'string' || typeof value.recordId === 'number'
+      ? value.recordId
+      : typeof value.record?.recordId === 'string' || typeof value.record?.recordId === 'number'
+        ? value.record.recordId
+        : undefined;
+  const recordId = rawRecordId === undefined ? undefined : String(rawRecordId).trim();
+
+  return {
+    ...layoutArg,
+    recordId: recordId && recordId.length > 0 ? recordId : undefined
   };
 }
 

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   openJsonDocument,
   parseLayoutArg,
+  parseRecordArg,
   promptForLayout,
   resolveProfileFromArg,
   showCommandError
@@ -25,6 +26,7 @@ import { QueryBuilderPanel } from '../webviews/queryBuilder';
 import { RecordViewerPanel } from '../webviews/recordViewer';
 import { retryWithBackoff, type BackoffPolicy } from '../utils/backoff';
 import { showConnectionQuickPick } from '../views/connectionStatusBar';
+import { buildWebDirectRecordUrl, DEFAULT_WEBDIRECT_BASE_PATH } from '../utils/webDirectUrl';
 
 interface RegisterCoreCommandDeps {
   context: vscode.ExtensionContext;
@@ -46,6 +48,7 @@ interface RegisterCoreCommandDeps {
   /** Resolved at call time so settings updates are picked up live. */
   getConnectBackoffPolicy?: () => BackoffPolicy;
   getConnectionWizardTestPolicy?: () => 'off' | 'warn' | 'block';
+  getWebDirectBasePath?: () => string;
 }
 
 function isRetryableConnectError(error: unknown): boolean {
@@ -392,6 +395,59 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
         });
       }
     }),
+
+    vscode.commands.registerCommand(
+      'filemakerDataApiTools.copyWebDirectUrlForCurrentRecord',
+      async (arg: unknown) => {
+        const contextArg = parseRecordArg(arg);
+        const profile = await resolveProfileFromArg(contextArg, profileStore, true);
+        if (!profile) {
+          return;
+        }
+
+        const layout = contextArg.layout ?? (await promptForLayout(profile, fmClient));
+        if (!layout) {
+          return;
+        }
+
+        const recordId =
+          contextArg.recordId ??
+          (await vscode.window.showInputBox({
+            title: 'Copy WebDirect URL for Current Record',
+            prompt: 'Enter FileMaker record ID',
+            ignoreFocusOut: true,
+            validateInput: (value) => validateRecordId(value).error
+          }));
+        if (!recordId) {
+          return;
+        }
+
+        try {
+          const url = buildWebDirectRecordUrl({
+            profile,
+            layout,
+            recordId,
+            basePath: deps.getWebDirectBasePath?.() ?? DEFAULT_WEBDIRECT_BASE_PATH
+          });
+
+          await vscode.env.clipboard.writeText(url);
+          const action = await vscode.window.showInformationMessage(
+            `WebDirect URL copied: ${url}`,
+            'Open in Browser'
+          );
+
+          if (action === 'Open in Browser') {
+            await vscode.env.openExternal(vscode.Uri.parse(url));
+          }
+        } catch (error) {
+          await showCommandError(error, {
+            fallbackMessage: 'Failed to copy WebDirect URL.',
+            logger,
+            logMessage: 'Copy WebDirect URL command failed.'
+          });
+        }
+      }
+    ),
 
     vscode.commands.registerCommand('filemakerDataApiTools.openRecordViewer', async (arg: unknown) => {
       const contextArg = parseLayoutArg(arg);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -219,7 +219,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       schemaService.invalidateProfile(profileId);
     },
     getConnectBackoffPolicy: () => settingsService.getConnectBackoffPolicy(),
-    getConnectionWizardTestPolicy: () => settingsService.getConnectionWizardTestPolicy()
+    getConnectionWizardTestPolicy: () => settingsService.getConnectionWizardTestPolicy(),
+    getWebDirectBasePath: () => settingsService.getWebDirectBasePath()
   });
 
   const savedQueryDisposables = registerSavedQueriesCommands({

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -131,6 +131,15 @@ export class SettingsService {
     return normalizeApiPath(configured, '/fmi/data');
   }
 
+  public getWebDirectBasePath(): string {
+    const configured = this.getConfiguration('filemaker').get<string>(
+      'webDirect.basePath',
+      '/fmi/webd'
+    );
+
+    return normalizeApiPath(configured, '/fmi/webd');
+  }
+
   public getDefaultApiVersionPath(): string {
     const configured = this.getPreferred<string>(
       'filemaker',

--- a/extension/src/utils/webDirectUrl.ts
+++ b/extension/src/utils/webDirectUrl.ts
@@ -1,0 +1,52 @@
+import type { ConnectionProfile } from '../types/fm';
+
+export const DEFAULT_WEBDIRECT_BASE_PATH = '/fmi/webd';
+
+export interface WebDirectRecordUrlInput {
+  profile: Pick<ConnectionProfile, 'serverUrl' | 'database'>;
+  layout: string;
+  recordId: string;
+  basePath?: string;
+}
+
+export function normalizeWebDirectBasePath(
+  value: string | undefined,
+  fallback = DEFAULT_WEBDIRECT_BASE_PATH
+): string {
+  const trimmed = value?.trim() ?? '';
+  const normalized = trimmed.length > 0 ? trimmed : fallback;
+  const withLeadingSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  return withLeadingSlash.replace(/\/+$/, '') || fallback;
+}
+
+export function buildWebDirectRecordUrl(input: WebDirectRecordUrlInput): string {
+  const serverUrl = input.profile.serverUrl.trim();
+  const database = input.profile.database.trim();
+  const layout = input.layout.trim();
+  const recordId = input.recordId.trim();
+
+  if (!serverUrl) {
+    throw new Error('Connection profile is missing a server URL.');
+  }
+  if (!database) {
+    throw new Error('Connection profile is missing a database name.');
+  }
+  if (!layout) {
+    throw new Error('A layout name is required to build a WebDirect URL.');
+  }
+  if (!recordId) {
+    throw new Error('A record ID is required to build a WebDirect URL.');
+  }
+
+  const url = new URL(serverUrl);
+  const baseSegments = normalizeWebDirectBasePath(input.basePath).split('/').filter(Boolean);
+  const pathSegments = [...baseSegments, 'db', database, layout].map((segment) =>
+    encodeURIComponent(segment)
+  );
+
+  url.pathname = `/${pathSegments.join('/')}`;
+  url.search = '';
+  url.hash = `recordid=${encodeURIComponent(recordId)}`;
+
+  return url.toString();
+}

--- a/extension/src/views/fmExplorer.ts
+++ b/extension/src/views/fmExplorer.ts
@@ -23,6 +23,7 @@ export type ExplorerNodeKind =
   | 'savedQueriesRoot'
   | 'savedQuery'
   | 'layout'
+  | 'record'
   | 'fieldsRoot'
   | 'field'
   | 'schemaSnapshotsRoot'
@@ -36,6 +37,7 @@ export class FMExplorerItem extends vscode.TreeItem {
   public readonly kind: ExplorerNodeKind;
   public readonly profileId?: string;
   public readonly layoutName?: string;
+  public readonly recordId?: string;
   public readonly queryId?: string;
   public readonly fieldName?: string;
   public readonly snapshotId?: string;
@@ -48,6 +50,7 @@ export class FMExplorerItem extends vscode.TreeItem {
     collapsibleState?: vscode.TreeItemCollapsibleState;
     profileId?: string;
     layoutName?: string;
+    recordId?: string;
     queryId?: string;
     fieldName?: string;
     snapshotId?: string;
@@ -64,6 +67,7 @@ export class FMExplorerItem extends vscode.TreeItem {
     this.kind = options.kind;
     this.profileId = options.profileId;
     this.layoutName = options.layoutName;
+    this.recordId = options.recordId;
     this.queryId = options.queryId;
     this.fieldName = options.fieldName;
     this.snapshotId = options.snapshotId;

--- a/extension/test/unit/commands/core.test.ts
+++ b/extension/test/unit/commands/core.test.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import {
   parseProfileId,
   parseLayoutArg,
+  parseRecordArg,
   formatError
 } from '../../../src/commands/common';
 import { registerCoreCommands } from '../../../src/commands/index';
@@ -44,6 +45,24 @@ describe('parseLayoutArg', () => {
 
   it('returns empty object for null arg', () => {
     expect(parseLayoutArg(null)).toEqual({});
+  });
+});
+
+describe('parseRecordArg', () => {
+  it('extracts profile, layout, and recordId from explorer args', () => {
+    expect(parseRecordArg({ profileId: 'p1', layoutName: 'Contacts', recordId: 42 })).toEqual({
+      profileId: 'p1',
+      layout: 'Contacts',
+      recordId: '42'
+    });
+  });
+
+  it('extracts recordId from nested record payloads', () => {
+    expect(parseRecordArg({ layout: 'Invoices', record: { recordId: '  99  ' } })).toEqual({
+      profileId: undefined,
+      layout: 'Invoices',
+      recordId: '99'
+    });
   });
 });
 
@@ -105,7 +124,8 @@ describe('registerCoreCommands', () => {
         isProfileLocked: vi.fn().mockReturnValue(false)
       } as never,
       refreshExplorer: vi.fn(),
-      onProfileDisconnected: vi.fn()
+      onProfileDisconnected: vi.fn(),
+      getWebDirectBasePath: vi.fn(() => '/fmi/webd')
     };
   }
 
@@ -165,5 +185,52 @@ describe('registerCoreCommands', () => {
       ([name]) => name
     );
     expect(registeredNames).toContain('filemakerDataApiTools.editConnectionProfile');
+  });
+
+  it('registers the WebDirect URL command', () => {
+    const deps = createMockDeps();
+    registerCoreCommands(deps);
+
+    const registeredNames = vi.mocked(vscode.commands.registerCommand).mock.calls.map(
+      ([name]) => name
+    );
+    expect(registeredNames).toContain('filemakerDataApiTools.copyWebDirectUrlForCurrentRecord');
+  });
+
+  it('copies and optionally opens the WebDirect URL for a selected record', async () => {
+    const deps = createMockDeps();
+    (deps.profileStore as { getProfile: ReturnType<typeof vi.fn> }).getProfile = vi
+      .fn()
+      .mockResolvedValue({
+        id: 'p1',
+        name: 'Dev',
+        serverUrl: 'https://fm.example.com',
+        database: 'Contacts DB',
+        authMode: 'direct'
+      });
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValueOnce(
+      'Open in Browser' as never
+    );
+    registerCoreCommands(deps);
+
+    const call = vi
+      .mocked(vscode.commands.registerCommand)
+      .mock.calls.find(
+        ([name]) => name === 'filemakerDataApiTools.copyWebDirectUrlForCurrentRecord'
+      );
+    const handler = call?.[1] as ((arg: unknown) => Promise<void>) | undefined;
+    expect(handler).toBeDefined();
+
+    await handler?.({ profileId: 'p1', layoutName: 'Customer Detail', recordId: '42' });
+
+    const expectedUrl =
+      'https://fm.example.com/fmi/webd/db/Contacts%20DB/Customer%20Detail#recordid=42';
+    expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(expectedUrl);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      `WebDirect URL copied: ${expectedUrl}`,
+      'Open in Browser'
+    );
+    expect(vscode.Uri.parse).toHaveBeenCalledWith(expectedUrl);
+    expect(vscode.env.openExternal).toHaveBeenCalled();
   });
 });

--- a/extension/test/unit/services/settingsServiceDeprecated.test.ts
+++ b/extension/test/unit/services/settingsServiceDeprecated.test.ts
@@ -98,4 +98,11 @@ describe('SettingsService deprecation handling', () => {
     // Second consume clears
     expect(svc.consumeDeprecatedSettingsUsed()).toEqual([]);
   });
+
+  it('normalizes the WebDirect base path setting', () => {
+    const svc = service({
+      filemaker: { workspace: { 'webDirect.basePath': 'custom/webd/' } }
+    });
+    expect(svc.getWebDirectBasePath()).toBe('/custom/webd');
+  });
 });

--- a/extension/test/unit/views/fmExplorer.test.ts
+++ b/extension/test/unit/views/fmExplorer.test.ts
@@ -199,17 +199,19 @@ describe('FMExplorerProvider', () => {
 describe('FMExplorerItem', () => {
   it('stores kind and contextValue', () => {
     const item = new FMExplorerItem({
-      kind: 'layout',
-      label: 'Contacts',
-      contextValue: 'fmLayout',
+      kind: 'record',
+      label: 'Record 42',
+      contextValue: 'fmRecord',
       profileId: 'p1',
-      layoutName: 'Contacts'
+      layoutName: 'Contacts',
+      recordId: '42'
     });
 
-    expect(item.kind).toBe('layout');
-    expect(item.contextValue).toBe('fmLayout');
+    expect(item.kind).toBe('record');
+    expect(item.contextValue).toBe('fmRecord');
     expect(item.profileId).toBe('p1');
     expect(item.layoutName).toBe('Contacts');
+    expect(item.recordId).toBe('42');
   });
 
   it('defaults collapsible state to None', () => {

--- a/extension/test/unit/webDirectUrl.test.ts
+++ b/extension/test/unit/webDirectUrl.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWebDirectRecordUrl, normalizeWebDirectBasePath } from '../../src/utils/webDirectUrl';
+
+describe('WebDirect URL helpers', () => {
+  const profile = {
+    serverUrl: 'https://fm.example.com',
+    database: 'Contacts DB'
+  };
+
+  it('builds a record URL with encoded database, layout, and record id', () => {
+    expect(
+      buildWebDirectRecordUrl({
+        profile,
+        layout: 'Customer Detail',
+        recordId: '42 9'
+      })
+    ).toBe('https://fm.example.com/fmi/webd/db/Contacts%20DB/Customer%20Detail#recordid=42%209');
+  });
+
+  it('uses a configured base path without trailing slash drift', () => {
+    expect(
+      buildWebDirectRecordUrl({
+        profile,
+        layout: 'Invoices',
+        recordId: '1',
+        basePath: 'custom/webdirect/'
+      })
+    ).toBe('https://fm.example.com/custom/webdirect/db/Contacts%20DB/Invoices#recordid=1');
+  });
+
+  it('normalizes blank base paths to the default', () => {
+    expect(normalizeWebDirectBasePath('   ')).toBe('/fmi/webd');
+  });
+
+  it('rejects missing required inputs', () => {
+    expect(() =>
+      buildWebDirectRecordUrl({
+        profile: { ...profile, database: '' },
+        layout: 'Contacts',
+        recordId: '1'
+      })
+    ).toThrow(/database/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a WebDirect URL helper for FileMaker records so users can copy a URL for the selected/current record and optionally open it in the system browser.

## Linked issue

Closes #182

## Changes

- Added `FileMaker: Copy WebDirect URL for Current Record` to the command palette and explorer record context menu.
- Added WebDirect URL construction with encoded database/layout/record segments and configurable `filemaker.webDirect.basePath` defaulting to `/fmi/webd`.
- Added record-aware command argument parsing and explorer item record metadata support.
- Added unit coverage for URL construction, settings normalization, command registration/execution, and explorer record metadata.

## Acceptance criteria mirror

- [x] Command available in palette and right-click on record context items.
- [x] Clipboard receives the computed WebDirect URL.
- [x] Toast shows the URL and `Open in Browser` launches `vscode.env.openExternal`.

## Test plan

- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run package:check`
- [x] `ai-pipeline validate --id 182` (no validation.local commands declared)

## Changelog entry

- [FEATURE] Added a WebDirect URL helper command that copies the current record URL and can open it in the system browser.
