### PR TITLE
[minor] Add layout object inspector

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [FEATURE] Added a Layout Inspector view that shows selected layout fields, portals, value lists, and field validation rules with refreshable session caching.
+
 - Attributed the extension to ABD Enterprises in README and `package.json`:
   - new `author` field pointing at `https://abdenterprises.com`
   - `homepage` now resolves to `abdenterprises.com?ref=vscode` (with the GitHub repo still linked via `repository`)

--- a/extension/package.json
+++ b/extension/package.json
@@ -87,6 +87,12 @@
           "name": "Connections",
           "contextualTitle": "FileMaker",
           "icon": "media/filemaker.svg"
+        },
+        {
+          "id": "filemakerLayoutInspector",
+          "name": "Layout Inspector",
+          "contextualTitle": "FileMaker",
+          "icon": "media/filemaker.svg"
         }
       ]
     },
@@ -94,6 +100,10 @@
       {
         "view": "filemakerExplorer",
         "contents": "No FileMaker connections yet.\n[Add Connection Profile](command:filemakerDataApiTools.addConnectionProfile)\n[Open Walkthrough](command:filemakerDataApiTools.openWelcomeWalkthrough)\n\nYour passwords stay in the OS keychain. Learn more in the [User Guide](command:filemakerDataApiTools.openUserGuide)."
+      },
+      {
+        "view": "filemakerLayoutInspector",
+        "contents": "Select a layout in Connections or choose one directly.\n[Select Layout](command:filemakerDataApiTools.selectLayoutForInspector)\n[Connect](command:filemakerDataApiTools.connect)"
       }
     ],
     "walkthroughs": [
@@ -198,6 +208,16 @@
       {
         "command": "filemakerDataApiTools.openLayoutMetadata",
         "title": "FileMaker: Open Layout Metadata"
+      },
+      {
+        "command": "filemakerDataApiTools.selectLayoutForInspector",
+        "title": "FileMaker: Select Layout for Inspector",
+        "icon": "$(inspect)"
+      },
+      {
+        "command": "filemakerDataApiTools.refreshLayoutInspector",
+        "title": "FileMaker: Refresh Layout Inspector",
+        "icon": "$(refresh)"
       },
       {
         "command": "filemakerDataApiTools.refreshSchemaCache",
@@ -396,6 +416,16 @@
           "command": "filemakerDataApiTools.refreshExplorer",
           "when": "view == filemakerExplorer",
           "group": "navigation@2"
+        },
+        {
+          "command": "filemakerDataApiTools.selectLayoutForInspector",
+          "when": "view == filemakerLayoutInspector",
+          "group": "navigation@1"
+        },
+        {
+          "command": "filemakerDataApiTools.refreshLayoutInspector",
+          "when": "view == filemakerLayoutInspector",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [
@@ -440,6 +470,11 @@
           "group": "navigation@1"
         },
         {
+          "command": "filemakerDataApiTools.selectLayoutForInspector",
+          "when": "view == filemakerExplorer && viewItem == fmLayout",
+          "group": "navigation@2"
+        },
+        {
           "command": "filemakerDataApiTools.runSavedQuery",
           "when": "view == filemakerExplorer && viewItem == fmSavedQuery",
           "group": "inline@1"
@@ -467,32 +502,32 @@
         {
           "command": "filemakerDataApiTools.editRecordById",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "filemakerDataApiTools.captureSchemaSnapshot",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@3"
+          "group": "navigation@4"
         },
         {
           "command": "filemakerDataApiTools.diffAgainstLatestSnapshot",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@4"
+          "group": "navigation@5"
         },
         {
           "command": "filemakerDataApiTools.generateTypesForLayout",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@5"
+          "group": "navigation@6"
         },
         {
           "command": "filemakerDataApiTools.batchExportFind",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@6"
+          "group": "navigation@7"
         },
         {
           "command": "filemakerDataApiTools.batchUpdateFromFile",
           "when": "view == filemakerExplorer && viewItem == fmLayout",
-          "group": "navigation@7"
+          "group": "navigation@8"
         },
         {
           "command": "filemakerDataApiTools.openSchemaSnapshotJson",
@@ -558,6 +593,8 @@
         { "command": "filemakerDataApiTools.removeConnectionProfile", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.selectActiveProfile", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.listLayouts", "when": "filemaker.hasProfiles" },
+        { "command": "filemakerDataApiTools.selectLayoutForInspector", "when": "filemaker.hasProfiles" },
+        { "command": "filemakerDataApiTools.refreshLayoutInspector", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.refreshSchemaCache", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.openScriptRunner", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.openQueryBuilder", "when": "filemaker.hasProfiles" },

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -43,6 +43,7 @@ interface RegisterCoreCommandDeps {
    */
   refreshConnectionStatus?: () => void;
   onProfileDisconnected?: (profileId: string) => void;
+  onLayoutSelected?: (profileId: string, layout: string) => void;
   /** Resolved at call time so settings updates are picked up live. */
   getConnectBackoffPolicy?: () => BackoffPolicy;
   getConnectionWizardTestPolicy?: () => 'off' | 'warn' | 'block';
@@ -86,7 +87,8 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
     roleGuard,
     refreshExplorer,
     refreshConnectionStatus,
-    onProfileDisconnected
+    onProfileDisconnected,
+    onLayoutSelected
   } = deps;
 
   return [
@@ -200,6 +202,21 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
           refreshExplorer();
           refreshConnectionStatus?.();
           vscode.window.showInformationMessage(`Connected to "${profile.name}".`);
+
+          if (onLayoutSelected) {
+            try {
+              const layout = await promptForLayout(profile, fmClient);
+              if (layout) {
+                onLayoutSelected(profile.id, layout);
+                await vscode.commands.executeCommand('filemakerLayoutInspector.focus');
+              }
+            } catch (error) {
+              logger.warn('Failed to select a layout for the inspector after connect.', {
+                profileId: profile.id,
+                error
+              });
+            }
+          }
         } catch (error) {
           await showCommandError(error, {
             fallbackMessage: 'Failed to connect to FileMaker profile.',

--- a/extension/src/commands/layoutInspector.ts
+++ b/extension/src/commands/layoutInspector.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+
+import type { FMClient } from '../services/fmClient';
+import type { Logger } from '../services/logger';
+import type { ProfileStore } from '../services/profileStore';
+import type { LayoutInspectorProvider } from '../views/layoutInspector';
+import { parseLayoutArg, promptForLayout, resolveProfileFromArg, showCommandError } from './common';
+
+interface RegisterLayoutInspectorCommandDeps {
+  profileStore: ProfileStore;
+  fmClient: FMClient;
+  layoutInspectorProvider: LayoutInspectorProvider;
+  logger: Logger;
+}
+
+export function registerLayoutInspectorCommands(
+  deps: RegisterLayoutInspectorCommandDeps
+): vscode.Disposable[] {
+  const { profileStore, fmClient, layoutInspectorProvider, logger } = deps;
+
+  return [
+    vscode.commands.registerCommand(
+      'filemakerDataApiTools.selectLayoutForInspector',
+      async (arg: unknown) => {
+        const contextArg = parseLayoutArg(arg);
+        const profile = await resolveProfileFromArg(contextArg, profileStore, true);
+
+        if (!profile) {
+          return;
+        }
+
+        const layout = contextArg.layout ?? (await promptForLayout(profile, fmClient));
+        if (!layout) {
+          return;
+        }
+
+        layoutInspectorProvider.selectLayout(profile.id, layout);
+        await vscode.commands.executeCommand('filemakerLayoutInspector.focus');
+      }
+    ),
+
+    vscode.commands.registerCommand('filemakerDataApiTools.refreshLayoutInspector', async () => {
+      try {
+        await layoutInspectorProvider.refreshCurrent();
+      } catch (error) {
+        await showCommandError(error, {
+          fallbackMessage: 'Failed to refresh Layout Inspector.',
+          logger,
+          logMessage: 'Layout Inspector refresh failed.'
+        });
+      }
+    })
+  ];
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -8,6 +8,7 @@ import { registerFmWebProjectCommands } from './commands/fmWebProject';
 import { registerCoreCommands } from './commands';
 import { registerHistoryCommands } from './commands/history';
 import { registerJobsCommands } from './commands/jobs';
+import { registerLayoutInspectorCommands } from './commands/layoutInspector';
 import { registerOfflineCommands } from './commands/offline';
 import { registerPluginCommands } from './commands/plugins';
 import { registerRecordEditCommands } from './commands/recordEdit';
@@ -41,6 +42,7 @@ import { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
 import { PluginRegistry } from './plugins/pluginRegistry';
 import { ConnectionStatusBar } from './views/connectionStatusBar';
 import { FMExplorerProvider } from './views/fmExplorer';
+import { LayoutInspectorProvider } from './views/layoutInspector';
 import { OfflineStatusBar } from './views/offlineStatusBar';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -181,11 +183,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     offlineModeService,
     logger
   );
+  const layoutInspectorProvider = new LayoutInspectorProvider(profileStore, schemaService);
 
-  const treeViewDisposable = vscode.window.registerTreeDataProvider(
-    'filemakerExplorer',
-    fmExplorerProvider
-  );
+  const filemakerExplorerTree = vscode.window.createTreeView('filemakerExplorer', {
+    treeDataProvider: fmExplorerProvider
+  });
+  const layoutInspectorTree = vscode.window.createTreeView('filemakerLayoutInspector', {
+    treeDataProvider: layoutInspectorProvider
+  });
+  const layoutSelectionDisposable = filemakerExplorerTree.onDidChangeSelection((event) => {
+    const layoutItem = event.selection.find(
+      (item) => item.kind === 'layout' && item.profileId && item.layoutName
+    );
+
+    if (layoutItem?.profileId && layoutItem.layoutName) {
+      layoutInspectorProvider.selectLayout(layoutItem.profileId, layoutItem.layoutName);
+    }
+  });
 
   // Forward-declared so refreshExplorer (called by registered command handlers)
   // can re-evaluate command-palette contexts after profile / snapshot / project
@@ -217,9 +231,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     refreshConnectionStatus: () => connectionStatusBar.refresh(),
     onProfileDisconnected: (profileId) => {
       schemaService.invalidateProfile(profileId);
+      layoutInspectorProvider.clearProfile(profileId);
     },
+    onLayoutSelected: (profileId, layout) =>
+      layoutInspectorProvider.selectLayout(profileId, layout),
     getConnectBackoffPolicy: () => settingsService.getConnectBackoffPolicy(),
     getConnectionWizardTestPolicy: () => settingsService.getConnectionWizardTestPolicy()
+  });
+
+  const layoutInspectorDisposables = registerLayoutInspectorCommands({
+    profileStore,
+    fmClient,
+    layoutInspectorProvider,
+    logger
   });
 
   const savedQueryDisposables = registerSavedQueriesCommands({
@@ -355,8 +379,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(
     offlineStatusBar,
     connectionStatusBar,
-    treeViewDisposable,
+    filemakerExplorerTree,
+    layoutInspectorTree,
+    layoutSelectionDisposable,
     ...coreCommandDisposables,
+    ...layoutInspectorDisposables,
     ...savedQueryDisposables,
     ...schemaDisposables,
     ...schemaSnapshotDisposables,

--- a/extension/src/services/schemaService.ts
+++ b/extension/src/services/schemaService.ts
@@ -43,6 +43,10 @@ export class SchemaService {
     }
   }
 
+  public invalidateLayout(profile: ConnectionProfile, layout: string): void {
+    this.cache.delete(buildSchemaCacheKey(profile, layout));
+  }
+
   public async getFields(profile: ConnectionProfile, layout: string): Promise<SchemaMetadataResult> {
     return this.getLayoutSchema(profile, layout);
   }

--- a/extension/src/utils/layoutInspector.ts
+++ b/extension/src/utils/layoutInspector.ts
@@ -1,0 +1,157 @@
+import type { FileMakerFieldMetadata, SchemaMetadataResult, ValueList } from '../types/fm';
+import { extractPortalMetadata } from './portalUtils';
+import { extractValueLists } from './valueListParser';
+
+export interface LayoutInspectorField {
+  name: string;
+  type?: string;
+  repetitions?: number;
+  isGlobal: boolean;
+  validation?: Record<string, unknown>;
+}
+
+export interface LayoutInspectorPortal {
+  key: string;
+  relatedTable: string;
+  fields: Array<{
+    name: string;
+    type?: string;
+  }>;
+}
+
+export interface LayoutInspectorValidationRule {
+  fieldName: string;
+  summary: string;
+  details: Record<string, unknown>;
+}
+
+export interface LayoutInspectorModel {
+  fields: LayoutInspectorField[];
+  portals: LayoutInspectorPortal[];
+  valueLists: ValueList[];
+  validations: LayoutInspectorValidationRule[];
+}
+
+export function buildLayoutInspectorModel(schema: SchemaMetadataResult): LayoutInspectorModel {
+  const metadata = schema.metadata ?? {};
+  const fields = schema.fields.map(toInspectorField);
+  const portals = extractInspectorPortals(metadata);
+  const valueLists = extractValueLists(metadata);
+  const validations = fields
+    .filter((field) => field.validation && Object.keys(field.validation).length > 0)
+    .map((field) => ({
+      fieldName: field.name,
+      summary: summarizeValidation(field.validation),
+      details: field.validation ?? {}
+    }));
+
+  return {
+    fields,
+    portals,
+    valueLists,
+    validations
+  };
+}
+
+function toInspectorField(field: FileMakerFieldMetadata): LayoutInspectorField {
+  return {
+    name: field.name,
+    type: field.result ?? field.type,
+    repetitions: field.repetitions,
+    isGlobal: isGlobalField(field),
+    validation: field.validation
+  };
+}
+
+function isGlobalField(field: FileMakerFieldMetadata): boolean {
+  const rawGlobal = field.global ?? field.isGlobal ?? field.globalStorage;
+  if (typeof rawGlobal === 'boolean') {
+    return rawGlobal;
+  }
+
+  if (typeof rawGlobal === 'string' && rawGlobal.toLowerCase() === 'true') {
+    return true;
+  }
+
+  const storage = field.storage ?? field.storageType;
+  return typeof storage === 'string' && storage.toLowerCase().includes('global');
+}
+
+function extractInspectorPortals(metadata: Record<string, unknown>): LayoutInspectorPortal[] {
+  const portalMetadata = extractPortalMetadata(metadata);
+
+  return Object.entries(portalMetadata)
+    .map(([key, fields]) => ({
+      key,
+      relatedTable: inferRelatedTable(
+        key,
+        fields.map((field) => field.name)
+      ),
+      fields: fields.map((field) => ({
+        name: field.name,
+        type: field.result ?? field.type
+      }))
+    }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function inferRelatedTable(portalKey: string, fieldNames: string[]): string {
+  const tablePrefixes = fieldNames
+    .map((fieldName) => {
+      const separatorIndex = fieldName.indexOf('::');
+      return separatorIndex > 0 ? fieldName.slice(0, separatorIndex) : undefined;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  const firstPrefix = tablePrefixes[0];
+  if (firstPrefix) {
+    return firstPrefix;
+  }
+
+  return portalKey;
+}
+
+function summarizeValidation(validation: Record<string, unknown> | undefined): string {
+  if (!validation) {
+    return '';
+  }
+
+  const enabledEntries = Object.entries(validation).filter(([, value]) => isMeaningfulRule(value));
+  if (enabledEntries.length === 0) {
+    return 'Validation configured';
+  }
+
+  return enabledEntries
+    .map(([key, value]) => {
+      if (typeof value === 'boolean') {
+        return key;
+      }
+
+      if (typeof value === 'string' || typeof value === 'number') {
+        return `${key}: ${value}`;
+      }
+
+      return key;
+    })
+    .join(', ');
+}
+
+function isMeaningfulRule(value: unknown): boolean {
+  if (value === undefined || value === null || value === false) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value).length > 0;
+  }
+
+  return true;
+}

--- a/extension/src/views/layoutInspector.ts
+++ b/extension/src/views/layoutInspector.ts
@@ -1,0 +1,361 @@
+import * as vscode from 'vscode';
+
+import type { ProfileStore } from '../services/profileStore';
+import type { SchemaService } from '../services/schemaService';
+import {
+  buildLayoutInspectorModel,
+  type LayoutInspectorField,
+  type LayoutInspectorModel,
+  type LayoutInspectorPortal,
+  type LayoutInspectorValidationRule
+} from '../utils/layoutInspector';
+
+type LayoutInspectorNodeKind =
+  | 'category'
+  | 'field'
+  | 'portal'
+  | 'portalField'
+  | 'valueList'
+  | 'validation'
+  | 'placeholder';
+
+type LayoutInspectorCategory = 'fields' | 'portals' | 'valueLists' | 'validations';
+
+interface LayoutInspectorSelection {
+  profileId: string;
+  layoutName: string;
+}
+
+class LayoutInspectorItem extends vscode.TreeItem {
+  public readonly kind: LayoutInspectorNodeKind;
+  public readonly category?: LayoutInspectorCategory;
+  public readonly portalKey?: string;
+
+  public constructor(options: {
+    kind: LayoutInspectorNodeKind;
+    label: string;
+    collapsibleState?: vscode.TreeItemCollapsibleState;
+    category?: LayoutInspectorCategory;
+    portalKey?: string;
+    description?: string;
+    tooltip?: string;
+    iconPath?: vscode.ThemeIcon;
+    contextValue?: string;
+  }) {
+    super(options.label, options.collapsibleState ?? vscode.TreeItemCollapsibleState.None);
+
+    this.kind = options.kind;
+    this.category = options.category;
+    this.portalKey = options.portalKey;
+    this.description = options.description;
+    this.tooltip = options.tooltip;
+    this.iconPath = options.iconPath;
+    this.contextValue = options.contextValue;
+  }
+}
+
+interface LayoutInspectorCacheEntry {
+  profileName: string;
+  database: string;
+  model: LayoutInspectorModel;
+}
+
+export class LayoutInspectorProvider implements vscode.TreeDataProvider<LayoutInspectorItem> {
+  private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<
+    LayoutInspectorItem | undefined
+  >();
+  private readonly cache = new Map<string, LayoutInspectorCacheEntry>();
+  private selection: LayoutInspectorSelection | undefined;
+
+  public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
+
+  public constructor(
+    private readonly profileStore: ProfileStore,
+    private readonly schemaService: SchemaService
+  ) {}
+
+  public selectLayout(profileId: string, layoutName: string): void {
+    this.selection = { profileId, layoutName };
+    this.onDidChangeTreeDataEmitter.fire(undefined);
+  }
+
+  public clearProfile(profileId: string): void {
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(`${profileId}:`)) {
+        this.cache.delete(key);
+      }
+    }
+
+    if (this.selection?.profileId === profileId) {
+      this.selection = undefined;
+      this.onDidChangeTreeDataEmitter.fire(undefined);
+    }
+  }
+
+  public async refreshCurrent(): Promise<void> {
+    if (!this.selection) {
+      this.onDidChangeTreeDataEmitter.fire(undefined);
+      return;
+    }
+
+    const profile = await this.profileStore.getProfile(this.selection.profileId);
+    if (profile) {
+      this.schemaService.invalidateLayout(profile, this.selection.layoutName);
+    }
+
+    this.cache.delete(this.cacheKey(this.selection.profileId, this.selection.layoutName));
+    this.onDidChangeTreeDataEmitter.fire(undefined);
+  }
+
+  public getTreeItem(element: LayoutInspectorItem): vscode.TreeItem {
+    return element;
+  }
+
+  public async getChildren(element?: LayoutInspectorItem): Promise<LayoutInspectorItem[]> {
+    if (!this.selection) {
+      return [];
+    }
+
+    const entry = await this.getModel();
+    if (!entry) {
+      return [
+        new LayoutInspectorItem({
+          kind: 'placeholder',
+          label: 'Layout metadata unavailable',
+          description: 'Refresh or select another layout.',
+          iconPath: new vscode.ThemeIcon('warning')
+        })
+      ];
+    }
+
+    if (!element) {
+      return this.getCategoryItems(entry.model, entry.profileName, entry.database);
+    }
+
+    if (element.kind !== 'category' || !element.category) {
+      if (element.kind === 'portal' && element.portalKey) {
+        return this.getPortalFieldItems(entry.model, element.portalKey);
+      }
+
+      return [];
+    }
+
+    switch (element.category) {
+      case 'fields':
+        return entry.model.fields.map((field) => toFieldItem(field));
+      case 'portals':
+        return entry.model.portals.length > 0
+          ? entry.model.portals.map((portal) => toPortalItem(portal))
+          : [emptyItem('No portals on this layout')];
+      case 'valueLists':
+        return entry.model.valueLists.length > 0
+          ? entry.model.valueLists.map(
+              (valueList) =>
+                new LayoutInspectorItem({
+                  kind: 'valueList',
+                  label: valueList.name,
+                  description: `${valueList.values.length} item${valueList.values.length === 1 ? '' : 's'}`,
+                  tooltip: valueList.values
+                    .slice(0, 25)
+                    .map((item) =>
+                      item.displayValue === item.value
+                        ? item.value
+                        : `${item.value} -> ${item.displayValue}`
+                    )
+                    .join('\n'),
+                  iconPath: new vscode.ThemeIcon('list-unordered'),
+                  contextValue: 'fmLayoutInspectorValueList'
+                })
+            )
+          : [emptyItem('No value lists on this layout')];
+      case 'validations':
+        return entry.model.validations.length > 0
+          ? entry.model.validations.map((validation) => toValidationItem(validation))
+          : [emptyItem('No field validation rules')];
+    }
+  }
+
+  private getCategoryItems(
+    model: LayoutInspectorModel,
+    profileName: string,
+    database: string
+  ): LayoutInspectorItem[] {
+    const layoutName = this.selection?.layoutName ?? '';
+    const tooltip = [
+      `Profile: ${profileName}`,
+      `Database: ${database}`,
+      `Layout: ${layoutName}`
+    ].join('\n');
+
+    return [
+      new LayoutInspectorItem({
+        kind: 'category',
+        category: 'fields',
+        label: 'Fields',
+        description: `${model.fields.length}`,
+        tooltip,
+        collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+        iconPath: new vscode.ThemeIcon('symbol-field'),
+        contextValue: 'fmLayoutInspectorCategory'
+      }),
+      new LayoutInspectorItem({
+        kind: 'category',
+        category: 'portals',
+        label: 'Portals',
+        description: `${model.portals.length}`,
+        tooltip,
+        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+        iconPath: new vscode.ThemeIcon('symbol-namespace'),
+        contextValue: 'fmLayoutInspectorCategory'
+      }),
+      new LayoutInspectorItem({
+        kind: 'category',
+        category: 'valueLists',
+        label: 'Value Lists',
+        description: `${model.valueLists.length}`,
+        tooltip,
+        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+        iconPath: new vscode.ThemeIcon('list-unordered'),
+        contextValue: 'fmLayoutInspectorCategory'
+      }),
+      new LayoutInspectorItem({
+        kind: 'category',
+        category: 'validations',
+        label: 'Field Validation',
+        description: `${model.validations.length}`,
+        tooltip,
+        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+        iconPath: new vscode.ThemeIcon('shield'),
+        contextValue: 'fmLayoutInspectorCategory'
+      })
+    ];
+  }
+
+  private async getModel(): Promise<LayoutInspectorCacheEntry | undefined> {
+    if (!this.selection) {
+      return undefined;
+    }
+
+    const cacheKey = this.cacheKey(this.selection.profileId, this.selection.layoutName);
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const profile = await this.profileStore.getProfile(this.selection.profileId);
+    if (!profile) {
+      return undefined;
+    }
+
+    const schema = await this.schemaService.getLayoutSchema(profile, this.selection.layoutName);
+    if (!schema.supported) {
+      return undefined;
+    }
+
+    const entry = {
+      profileName: profile.name,
+      database: profile.database,
+      model: buildLayoutInspectorModel(schema)
+    };
+
+    this.cache.set(cacheKey, entry);
+    return entry;
+  }
+
+  private getPortalFieldItems(
+    model: LayoutInspectorModel,
+    portalKey: string
+  ): LayoutInspectorItem[] {
+    const portal = model.portals.find((item) => item.key === portalKey);
+    if (!portal) {
+      return [];
+    }
+
+    return portal.fields.map(
+      (field) =>
+        new LayoutInspectorItem({
+          kind: 'portalField',
+          label: field.name,
+          description: field.type,
+          tooltip: [
+            `Portal: ${portal.key}`,
+            `Related table: ${portal.relatedTable}`,
+            `Field: ${field.name}`
+          ]
+            .filter(Boolean)
+            .join('\n'),
+          iconPath: new vscode.ThemeIcon('symbol-field'),
+          contextValue: 'fmLayoutInspectorPortalField'
+        })
+    );
+  }
+
+  private cacheKey(profileId: string, layoutName: string): string {
+    return `${profileId}:${layoutName}`;
+  }
+}
+
+function toFieldItem(field: LayoutInspectorField): LayoutInspectorItem {
+  const descriptionParts = [field.type, field.isGlobal ? 'global' : undefined].filter(
+    (value): value is string => Boolean(value)
+  );
+
+  if (typeof field.repetitions === 'number') {
+    descriptionParts.push(`x${field.repetitions}`);
+  }
+
+  return new LayoutInspectorItem({
+    kind: 'field',
+    label: field.name,
+    description: descriptionParts.join(' • ') || undefined,
+    tooltip: [
+      `Field: ${field.name}`,
+      field.type ? `Type: ${field.type}` : undefined,
+      field.isGlobal ? 'Global storage' : undefined,
+      typeof field.repetitions === 'number' ? `Repetitions: ${field.repetitions}` : undefined
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join('\n'),
+    iconPath: new vscode.ThemeIcon(field.isGlobal ? 'globe' : 'symbol-field'),
+    contextValue: 'fmLayoutInspectorField'
+  });
+}
+
+function toPortalItem(portal: LayoutInspectorPortal): LayoutInspectorItem {
+  return new LayoutInspectorItem({
+    kind: 'portal',
+    label: portal.key,
+    portalKey: portal.key,
+    description: portal.relatedTable,
+    tooltip: [
+      `Portal key: ${portal.key}`,
+      `Related table: ${portal.relatedTable}`,
+      `${portal.fields.length} fields`
+    ].join('\n'),
+    collapsibleState:
+      portal.fields.length > 0
+        ? vscode.TreeItemCollapsibleState.Collapsed
+        : vscode.TreeItemCollapsibleState.None,
+    iconPath: new vscode.ThemeIcon('symbol-namespace'),
+    contextValue: 'fmLayoutInspectorPortal'
+  });
+}
+
+function toValidationItem(validation: LayoutInspectorValidationRule): LayoutInspectorItem {
+  return new LayoutInspectorItem({
+    kind: 'validation',
+    label: validation.fieldName,
+    description: validation.summary,
+    tooltip: JSON.stringify(validation.details, null, 2),
+    iconPath: new vscode.ThemeIcon('shield'),
+    contextValue: 'fmLayoutInspectorValidation'
+  });
+}
+
+function emptyItem(label: string): LayoutInspectorItem {
+  return new LayoutInspectorItem({
+    kind: 'placeholder',
+    label,
+    iconPath: new vscode.ThemeIcon('info')
+  });
+}

--- a/extension/test/setup.ts
+++ b/extension/test/setup.ts
@@ -34,7 +34,12 @@ vi.mock('vscode', () => {
       showOpenDialog: vi.fn(),
       showTextDocument: vi.fn(),
       createOutputChannel: vi.fn(() => outputChannel),
-      createWebviewPanel: vi.fn()
+      createWebviewPanel: vi.fn(),
+      createTreeView: vi.fn(() => ({
+        onDidChangeSelection: vi.fn(() => ({ dispose: vi.fn() })),
+        reveal: vi.fn(),
+        dispose: vi.fn()
+      }))
     },
     commands: {
       executeCommand: vi.fn(),

--- a/extension/test/unit/layoutInspector.test.ts
+++ b/extension/test/unit/layoutInspector.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLayoutInspectorModel } from '../../src/utils/layoutInspector';
+import type { SchemaMetadataResult } from '../../src/types/fm';
+
+describe('buildLayoutInspectorModel', () => {
+  it('extracts fields, portals, value lists, globals, and validation rules', () => {
+    const schema: SchemaMetadataResult = {
+      supported: true,
+      fromCache: false,
+      fields: [
+        {
+          name: 'Name',
+          result: 'text',
+          validation: {
+            notEmpty: true,
+            maxCharacters: 80
+          }
+        },
+        {
+          name: 'Company::AccountGlobal',
+          result: 'text',
+          storage: 'global'
+        }
+      ],
+      metadata: {
+        portalMetaData: {
+          InvoiceLines: [
+            { name: 'LineItems::Description', result: 'text' },
+            { name: 'LineItems::Amount', result: 'number' }
+          ]
+        },
+        valueLists: [
+          {
+            name: 'Statuses',
+            values: [{ value: 'Active', displayValue: 'Active' }]
+          }
+        ]
+      }
+    };
+
+    const model = buildLayoutInspectorModel(schema);
+
+    expect(model.fields).toEqual([
+      {
+        name: 'Name',
+        type: 'text',
+        repetitions: undefined,
+        isGlobal: false,
+        validation: { notEmpty: true, maxCharacters: 80 }
+      },
+      {
+        name: 'Company::AccountGlobal',
+        type: 'text',
+        repetitions: undefined,
+        isGlobal: true,
+        validation: undefined
+      }
+    ]);
+    expect(model.portals).toEqual([
+      {
+        key: 'InvoiceLines',
+        relatedTable: 'LineItems',
+        fields: [
+          { name: 'LineItems::Description', type: 'text' },
+          { name: 'LineItems::Amount', type: 'number' }
+        ]
+      }
+    ]);
+    expect(model.valueLists.map((valueList) => valueList.name)).toEqual(['Statuses']);
+    expect(model.validations).toEqual([
+      {
+        fieldName: 'Name',
+        summary: 'notEmpty, maxCharacters: 80',
+        details: { notEmpty: true, maxCharacters: 80 }
+      }
+    ]);
+  });
+});

--- a/extension/test/unit/views/layoutInspector.test.ts
+++ b/extension/test/unit/views/layoutInspector.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { LayoutInspectorProvider } from '../../../src/views/layoutInspector';
+import type { ConnectionProfile } from '../../../src/types/fm';
+
+const profile: ConnectionProfile = {
+  id: 'p1',
+  name: 'Dev',
+  authMode: 'direct',
+  serverUrl: 'https://fm.example.com',
+  database: 'CRM'
+};
+
+function createProvider() {
+  const profileStore = {
+    getProfile: vi.fn().mockResolvedValue(profile)
+  };
+  const schemaService = {
+    getLayoutSchema: vi.fn().mockResolvedValue({
+      supported: true,
+      fromCache: false,
+      fields: [
+        { name: 'Name', result: 'text' },
+        { name: 'GlobalStatus', result: 'text', isGlobal: true, validation: { notEmpty: true } }
+      ],
+      metadata: {
+        portalMetaData: {
+          Lines: [{ name: 'LineItems::Amount', result: 'number' }]
+        },
+        valueLists: [{ name: 'Statuses', values: [] }]
+      }
+    }),
+    invalidateLayout: vi.fn()
+  };
+
+  return {
+    provider: new LayoutInspectorProvider(profileStore as never, schemaService as never),
+    profileStore,
+    schemaService
+  };
+}
+
+describe('LayoutInspectorProvider', () => {
+  it('renders the four layout inspector categories for the selected layout', async () => {
+    const { provider } = createProvider();
+    provider.selectLayout('p1', 'Contacts');
+
+    const children = await provider.getChildren();
+
+    expect(children.map((item) => item.label)).toEqual([
+      'Fields',
+      'Portals',
+      'Value Lists',
+      'Field Validation'
+    ]);
+    expect(children.map((item) => item.description)).toEqual(['2', '1', '1', '1']);
+  });
+
+  it('uses its session cache until refresh is requested', async () => {
+    const { provider, schemaService } = createProvider();
+    provider.selectLayout('p1', 'Contacts');
+
+    await provider.getChildren();
+    await provider.getChildren();
+
+    expect(schemaService.getLayoutSchema).toHaveBeenCalledTimes(1);
+
+    await provider.refreshCurrent();
+    await provider.getChildren();
+
+    expect(schemaService.invalidateLayout).toHaveBeenCalledWith(profile, 'Contacts');
+    expect(schemaService.getLayoutSchema).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a dedicated Layout Inspector view in the FileMaker sidebar so selected layouts can be browsed without opening FileMaker Pro. The inspector shows fields, portals, value lists, and field validation rules with refreshable per-session caching.

## Linked issue

Closes #181

## Changes

- Added a Layout Inspector TreeDataProvider with categories for Fields, Portals, Value Lists, and Field Validation.
- Wired layout selection from the Connections tree and post-connect layout picking into the inspector.
- Added refresh/select commands and package contributions for the new sidebar view.
- Added layout-object parsing utilities and focused unit tests for extraction and cache refresh behavior.
- Added a changelog entry for the feature.

## Acceptance criteria mirror

- [x] Layout Inspector renders the 4 categories.
- [x] Refresh works.
- [x] Cached per session.
- [x] Works for layouts with 100+ fields without UI lag.

## Test plan

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run package:check`

## Changelog entry

- [FEATURE] Added a Layout Inspector view that shows selected layout fields, portals, value lists, and field validation rules with refreshable session caching.
