### PR TITLE
Script parameter JSON builder UI (#180)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -692,6 +692,11 @@
           "default": true,
           "description": "Enable Script Runner UI and script execution features."
         },
+        "filemaker.scripts.parameterBuilder.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the Script Runner JSON parameter builder."
+        },
         "filemaker.schema.snapshots.storage": {
           "type": "string",
           "enum": [

--- a/extension/src/webviews/scriptRunner/index.ts
+++ b/extension/src/webviews/scriptRunner/index.ts
@@ -127,13 +127,10 @@ export class ScriptRunnerPanel {
 
   private async sendInit(): Promise<void> {
     const profiles = await this.profileStore.listProfiles();
-    const scriptRunnerEnabled = vscode.workspace
-      .getConfiguration('filemaker')
-      .get<boolean>('features.scriptRunner.enabled', true);
-
-    const includeAuthByDefault = vscode.workspace
-      .getConfiguration('filemaker')
-      .get<boolean>('snippets.includeAuthByDefault', false);
+    const configuration = vscode.workspace.getConfiguration('filemaker');
+    const scriptRunnerEnabled = configuration.get<boolean>('features.scriptRunner.enabled', true);
+    const includeAuthByDefault = configuration.get<boolean>('snippets.includeAuthByDefault', false);
+    const parameterBuilderEnabled = configuration.get<boolean>('scripts.parameterBuilder.enabled', true);
 
     await this.panel.webview.postMessage({
       type: 'init',
@@ -147,7 +144,8 @@ export class ScriptRunnerPanel {
         activeProfileId: this.profileStore.getActiveProfileId(),
         defaults: this.pendingDefaults,
         scriptRunnerEnabled,
-        includeAuthByDefault
+        includeAuthByDefault,
+        parameterBuilderEnabled
       }
     });
 
@@ -426,8 +424,27 @@ export class ScriptRunnerPanel {
       </div>
       <div class="row">
         <label for="scriptParamInput">Script Parameter (optional)</label>
-        <textarea id="scriptParamInput" rows="3" placeholder="Any string payload"></textarea>
+        <div class="parameter-input-group">
+          <textarea id="scriptParamInput" rows="3" placeholder="Any string payload"></textarea>
+          <button id="buildParameterButton" type="button" aria-expanded="false" aria-controls="parameterBuilderPanel">Build Parameter</button>
+        </div>
       </div>
+      <section id="parameterBuilderPanel" class="panel builder-panel hidden" aria-labelledby="parameterBuilderTitle">
+        <h2 id="parameterBuilderTitle">Build Parameter</h2>
+        <div id="parameterRows" class="builder-rows"></div>
+        <div class="builder-toolbar">
+          <button id="addParameterRowButton" type="button">Add Row</button>
+        </div>
+        <div class="row">
+          <label for="parameterPreview">JSON Preview</label>
+          <pre id="parameterPreview" class="parameter-preview" role="status" aria-live="polite">{}</pre>
+        </div>
+        <p id="parameterBuilderStatus" class="status builder-status" role="status" aria-live="polite"></p>
+        <div class="actions builder-actions">
+          <button id="applyParameterButton" type="button">Apply Parameter</button>
+          <button id="closeParameterBuilderButton" type="button" class="secondary">Close</button>
+        </div>
+      </section>
       <div class="row inline">
         <label class="toggle"><input id="includeAuthCheckbox" type="checkbox" /> Include auth header in snippets</label>
       </div>

--- a/extension/src/webviews/scriptRunner/ui/index.js
+++ b/extension/src/webviews/scriptRunner/ui/index.js
@@ -6,14 +6,25 @@ const state = {
   defaults: undefined,
   layoutsByProfile: new Map(),
   scriptRunnerEnabled: true,
-  includeAuthByDefault: false
+  includeAuthByDefault: false,
+  parameterBuilderEnabled: true
 };
+
+const PARAMETER_VALUE_TYPES = ['string', 'number', 'bool', 'json'];
 
 const profileSelect = document.getElementById('profileSelect');
 const layoutSelect = document.getElementById('layoutSelect');
 const recordIdInput = document.getElementById('recordIdInput');
 const scriptNameInput = document.getElementById('scriptNameInput');
 const scriptParamInput = document.getElementById('scriptParamInput');
+const buildParameterButton = document.getElementById('buildParameterButton');
+const parameterBuilderPanel = document.getElementById('parameterBuilderPanel');
+const parameterRows = document.getElementById('parameterRows');
+const addParameterRowButton = document.getElementById('addParameterRowButton');
+const parameterPreview = document.getElementById('parameterPreview');
+const parameterBuilderStatus = document.getElementById('parameterBuilderStatus');
+const applyParameterButton = document.getElementById('applyParameterButton');
+const closeParameterBuilderButton = document.getElementById('closeParameterBuilderButton');
 const includeAuthCheckbox = document.getElementById('includeAuthCheckbox');
 const runButton = document.getElementById('runButton');
 const copyCurlButton = document.getElementById('copyCurlButton');
@@ -24,6 +35,7 @@ const rawResult = document.getElementById('rawResult');
 const scriptRunnerPanels = Array.from(document.querySelectorAll('.panel'));
 const scriptRunnerSkeleton = createLoadingSkeleton(['short', 'long', 'medium', 'long']);
 let scriptRunnerReady = false;
+let parameterRowCounter = 0;
 
 const scriptRunnerHeader = document.querySelector('.header');
 if (scriptRunnerHeader && scriptRunnerPanels.length > 0) {
@@ -62,6 +74,23 @@ window.addEventListener('message', (event) => {
 
 profileSelect.addEventListener('change', () => {
   requestLayouts(profileSelect.value);
+});
+
+buildParameterButton.addEventListener('click', () => {
+  openParameterBuilder();
+});
+
+addParameterRowButton.addEventListener('click', () => {
+  appendParameterRow();
+  renderParameterPreview();
+});
+
+applyParameterButton.addEventListener('click', () => {
+  applyParameterBuilder();
+});
+
+closeParameterBuilderButton.addEventListener('click', () => {
+  closeParameterBuilder();
 });
 
 runButton.addEventListener('click', () => {
@@ -113,12 +142,19 @@ function applyInit(payload) {
   state.defaults = payload.defaults;
   state.scriptRunnerEnabled = payload.scriptRunnerEnabled !== false;
   state.includeAuthByDefault = payload.includeAuthByDefault === true;
+  state.parameterBuilderEnabled = payload.parameterBuilderEnabled !== false;
 
   includeAuthCheckbox.checked = state.includeAuthByDefault;
   runButton.disabled = !state.scriptRunnerEnabled;
+  buildParameterButton.disabled = !state.scriptRunnerEnabled || !state.parameterBuilderEnabled;
+  buildParameterButton.classList.toggle('hidden', !state.parameterBuilderEnabled);
 
   if (!state.scriptRunnerEnabled) {
     setStatus('Script runner is disabled by setting.', true);
+  }
+
+  if (!state.parameterBuilderEnabled) {
+    closeParameterBuilder();
   }
 
   renderProfiles();
@@ -239,6 +275,347 @@ function collectPayload() {
   };
 }
 
+function openParameterBuilder() {
+  if (!state.parameterBuilderEnabled) {
+    return;
+  }
+
+  parameterRows.replaceChildren();
+  createRowsFromExistingParameter(scriptParamInput.value).forEach((row) => {
+    appendParameterRow(row);
+  });
+
+  parameterBuilderPanel.classList.remove('hidden');
+  buildParameterButton.setAttribute('aria-expanded', 'true');
+  renderParameterPreview();
+
+  const firstKeyInput = parameterRows.querySelector('[data-field="key"]');
+  if (firstKeyInput) {
+    firstKeyInput.focus();
+  }
+}
+
+function closeParameterBuilder() {
+  parameterBuilderPanel.classList.add('hidden');
+  buildParameterButton.setAttribute('aria-expanded', 'false');
+}
+
+function appendParameterRow(row = createEmptyParameterRow()) {
+  const rowId = `parameterBuilderRow${parameterRowCounter}`;
+  parameterRowCounter += 1;
+
+  const rowElement = document.createElement('div');
+  rowElement.className = 'builder-row';
+
+  const keyInput = document.createElement('input');
+  keyInput.id = `${rowId}Key`;
+  keyInput.type = 'text';
+  keyInput.placeholder = 'key';
+  keyInput.value = row.key;
+  keyInput.dataset.field = 'key';
+  keyInput.addEventListener('input', renderParameterPreview);
+
+  const typeSelect = document.createElement('select');
+  typeSelect.id = `${rowId}Type`;
+  typeSelect.dataset.field = 'type';
+  PARAMETER_VALUE_TYPES.forEach((type) => {
+    const option = document.createElement('option');
+    option.value = type;
+    option.textContent = getParameterTypeLabel(type);
+    typeSelect.appendChild(option);
+  });
+  typeSelect.value = normalizeParameterType(row.type);
+
+  const keyField = createBuilderField('Key', keyInput);
+  const typeField = createBuilderField('Type', typeSelect);
+  const valueField = document.createElement('div');
+  valueField.className = 'builder-field builder-value-field';
+
+  renderBuilderValueControl(valueField, rowId, typeSelect.value, row.value);
+
+  typeSelect.addEventListener('change', () => {
+    const existingValue = rowElement.querySelector('[data-field="value"]');
+    renderBuilderValueControl(
+      valueField,
+      rowId,
+      typeSelect.value,
+      existingValue ? existingValue.value : ''
+    );
+    renderParameterPreview();
+  });
+
+  const removeButton = document.createElement('button');
+  removeButton.type = 'button';
+  removeButton.textContent = 'Remove';
+  removeButton.className = 'secondary builder-remove-button';
+  removeButton.addEventListener('click', () => {
+    rowElement.remove();
+
+    if (!parameterRows.querySelector('.builder-row')) {
+      appendParameterRow();
+    }
+
+    renderParameterPreview();
+  });
+
+  rowElement.append(keyField, typeField, valueField, removeButton);
+  parameterRows.appendChild(rowElement);
+}
+
+function createBuilderField(labelText, control) {
+  const field = document.createElement('div');
+  field.className = 'builder-field';
+
+  const label = document.createElement('label');
+  label.textContent = labelText;
+  label.htmlFor = control.id;
+
+  field.append(label, control);
+  return field;
+}
+
+function renderBuilderValueControl(field, rowId, type, value) {
+  const label = document.createElement('label');
+  label.textContent = 'Value';
+  label.htmlFor = `${rowId}Value`;
+
+  const normalizedType = normalizeParameterType(type);
+  let control;
+
+  if (normalizedType === 'bool') {
+    control = document.createElement('select');
+    const trueOption = document.createElement('option');
+    trueOption.value = 'true';
+    trueOption.textContent = 'true';
+    const falseOption = document.createElement('option');
+    falseOption.value = 'false';
+    falseOption.textContent = 'false';
+    control.append(trueOption, falseOption);
+    control.value = value === 'false' ? 'false' : 'true';
+    control.addEventListener('change', renderParameterPreview);
+  } else if (normalizedType === 'number') {
+    control = document.createElement('input');
+    control.type = 'number';
+    control.step = 'any';
+    control.inputMode = 'decimal';
+    control.value = value;
+    control.addEventListener('input', renderParameterPreview);
+  } else {
+    control = document.createElement('textarea');
+    control.rows = normalizedType === 'json' ? 4 : 1;
+    control.value = value;
+    control.addEventListener('input', renderParameterPreview);
+  }
+
+  control.id = `${rowId}Value`;
+  control.dataset.field = 'value';
+  control.className = normalizedType === 'json' ? 'builder-json-value' : '';
+  field.replaceChildren(label, control);
+}
+
+function renderParameterPreview() {
+  const result = buildParameterJson(collectParameterBuilderRows());
+  parameterPreview.textContent = result.json || '';
+  parameterBuilderStatus.textContent = result.error || '';
+  parameterBuilderStatus.classList.toggle('error', Boolean(result.error));
+  applyParameterButton.disabled = Boolean(result.error);
+}
+
+function applyParameterBuilder() {
+  const result = buildParameterJson(collectParameterBuilderRows());
+
+  if (result.error) {
+    renderParameterPreview();
+    return;
+  }
+
+  scriptParamInput.value = result.json;
+  closeParameterBuilder();
+  setStatus('Parameter JSON generated.');
+}
+
+function collectParameterBuilderRows() {
+  return Array.from(parameterRows.querySelectorAll('.builder-row')).map((row) => {
+    const keyInput = row.querySelector('[data-field="key"]');
+    const typeSelect = row.querySelector('[data-field="type"]');
+    const valueInput = row.querySelector('[data-field="value"]');
+
+    return {
+      key: keyInput ? keyInput.value : '',
+      type: typeSelect ? typeSelect.value : 'string',
+      value: valueInput ? valueInput.value : ''
+    };
+  });
+}
+
+function createRowsFromExistingParameter(parameter) {
+  const trimmed = typeof parameter === 'string' ? parameter.trim() : '';
+  if (!trimmed) {
+    return [createEmptyParameterRow()];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return [createEmptyParameterRow()];
+    }
+
+    const rows = Object.entries(parsed).map(([key, value]) => ({
+      key,
+      ...inferParameterRowValue(value)
+    }));
+
+    return rows.length > 0 ? rows : [createEmptyParameterRow()];
+  } catch {
+    return [createEmptyParameterRow()];
+  }
+}
+
+function createEmptyParameterRow() {
+  return {
+    key: '',
+    type: 'string',
+    value: ''
+  };
+}
+
+function inferParameterRowValue(value) {
+  if (typeof value === 'string') {
+    return {
+      type: 'string',
+      value
+    };
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return {
+      type: 'number',
+      value: String(value)
+    };
+  }
+
+  if (typeof value === 'boolean') {
+    return {
+      type: 'bool',
+      value: value ? 'true' : 'false'
+    };
+  }
+
+  return {
+    type: 'json',
+    value: JSON.stringify(value, null, 2)
+  };
+}
+
+function buildParameterJson(rows) {
+  const output = Object.create(null);
+  const seenKeys = new Set();
+
+  for (const [index, row] of rows.entries()) {
+    const key = typeof row.key === 'string' ? row.key.trim() : '';
+    const type = normalizeParameterType(row.type);
+    const value = typeof row.value === 'string' ? row.value : '';
+    const isEmptyRow = key === '' && type === 'string' && value === '';
+
+    if (isEmptyRow) {
+      continue;
+    }
+
+    if (!key) {
+      return {
+        json: '',
+        error: `Row ${index + 1}: key is required.`
+      };
+    }
+
+    if (seenKeys.has(key)) {
+      return {
+        json: '',
+        error: `Row ${index + 1}: key "${key}" is duplicated.`
+      };
+    }
+
+    const parsed = parseParameterValue(type, value, index);
+    if (parsed.error) {
+      return {
+        json: '',
+        error: parsed.error
+      };
+    }
+
+    seenKeys.add(key);
+    output[key] = parsed.value;
+  }
+
+  return {
+    json: JSON.stringify(output, null, 2),
+    error: ''
+  };
+}
+
+function parseParameterValue(type, value, index) {
+  if (type === 'string') {
+    return {
+      value,
+      error: ''
+    };
+  }
+
+  if (type === 'number') {
+    const trimmed = value.trim();
+    const parsed = Number(trimmed);
+
+    if (!trimmed || !Number.isFinite(parsed)) {
+      return {
+        value: undefined,
+        error: `Row ${index + 1}: enter a valid number.`
+      };
+    }
+
+    return {
+      value: parsed,
+      error: ''
+    };
+  }
+
+  if (type === 'bool') {
+    return {
+      value: value === 'true',
+      error: ''
+    };
+  }
+
+  try {
+    return {
+      value: JSON.parse(value.trim()),
+      error: ''
+    };
+  } catch {
+    return {
+      value: undefined,
+      error: `Row ${index + 1}: enter valid JSON.`
+    };
+  }
+}
+
+function normalizeParameterType(type) {
+  return PARAMETER_VALUE_TYPES.includes(type) ? type : 'string';
+}
+
+function getParameterTypeLabel(type) {
+  switch (type) {
+    case 'number':
+      return 'Number';
+    case 'bool':
+      return 'Boolean';
+    case 'json':
+      return 'JSON';
+    case 'string':
+    default:
+      return 'String';
+  }
+}
+
 function createLoadingSkeleton(widths) {
   const skeleton = document.createElement('div');
   skeleton.className = 'loading-skeleton';
@@ -261,7 +638,9 @@ function syncSelectOptions(select, items, getValue, getLabel, emptyLabel) {
     return false;
   }
 
-  const existingOptions = new Map(Array.from(select.options).map((option) => [option.value, option]));
+  const existingOptions = new Map(
+    Array.from(select.options).map((option) => [option.value, option])
+  );
 
   items.forEach((item, index) => {
     const value = getValue(item);

--- a/extension/src/webviews/scriptRunner/ui/styles.css
+++ b/extension/src/webviews/scriptRunner/ui/styles.css
@@ -46,6 +46,10 @@ body {
   padding: clamp(12px, 2vw, 24px);
 }
 
+.hidden {
+  display: none !important;
+}
+
 .row {
   display: flex;
   flex-direction: column;
@@ -77,6 +81,75 @@ textarea {
   resize: vertical;
 }
 
+.parameter-input-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: start;
+}
+
+.parameter-input-group textarea {
+  min-width: 0;
+}
+
+.builder-panel {
+  margin: 10px 0;
+  padding: 14px;
+  border-radius: 8px;
+  background: #f8fbfb;
+}
+
+.builder-panel h2 {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.builder-rows {
+  display: grid;
+  gap: 10px;
+}
+
+.builder-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(110px, 140px) minmax(160px, 2fr) auto;
+  gap: 8px;
+  align-items: end;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+}
+
+.builder-field {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.builder-field textarea {
+  min-height: 36px;
+}
+
+.builder-json-value {
+  min-height: 94px;
+}
+
+.builder-toolbar,
+.builder-actions {
+  margin-top: 10px;
+}
+
+.parameter-preview {
+  min-height: 84px;
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  overflow: auto;
+  background: #0b1020;
+  color: #d6deeb;
+}
+
 .actions {
   display: flex;
   gap: 8px;
@@ -95,6 +168,15 @@ button {
 
 button:hover {
   background: var(--accent-strong);
+}
+
+button.secondary {
+  background: #e5e7eb;
+  color: var(--text);
+}
+
+button.secondary:hover {
+  background: #d1d5db;
 }
 
 button:disabled {
@@ -173,6 +255,11 @@ button:disabled {
 @media (max-width: 700px) {
   .container {
     padding: 10px;
+  }
+
+  .parameter-input-group,
+  .builder-row {
+    grid-template-columns: 1fr;
   }
 
   button {

--- a/extension/test/unit/scriptParameterBuilderUi.test.ts
+++ b/extension/test/unit/scriptParameterBuilderUi.test.ts
@@ -1,0 +1,252 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import vm from 'vm';
+
+import { describe, expect, it, vi } from 'vitest';
+
+type ParameterRow = {
+  key: string;
+  type: string;
+  value: string;
+};
+
+type BuilderResult = {
+  json: string;
+  error: string;
+};
+
+type BuildParameterJson = (rows: ParameterRow[]) => BuilderResult;
+type CreateRowsFromExistingParameter = (parameter: string) => ParameterRow[];
+
+interface FakeClassList {
+  add: (...tokens: string[]) => void;
+  remove: (...tokens: string[]) => void;
+  toggle: (token: string, force?: boolean) => boolean;
+  contains: (token: string) => boolean;
+}
+
+interface FakeElement {
+  children: FakeElement[];
+  style: Record<string, string>;
+  dataset: Record<string, string>;
+  classList: FakeClassList;
+  className: string;
+  textContent: string;
+  value: string;
+  checked: boolean;
+  disabled: boolean;
+  hidden: boolean;
+  type: string;
+  id: string;
+  htmlFor: string;
+  placeholder: string;
+  rows: number;
+  step: string;
+  inputMode: string;
+  appendChild: (child: FakeElement) => FakeElement;
+  append: (...children: FakeElement[]) => void;
+  replaceChildren: (...children: FakeElement[]) => void;
+  insertBefore: (child: FakeElement, before: FakeElement | null) => FakeElement;
+  remove: () => void;
+  addEventListener: (type: string, listener: unknown) => void;
+  setAttribute: (name: string, value: string) => void;
+  querySelector: (selector: string) => FakeElement | null;
+  querySelectorAll: (selector: string) => FakeElement[];
+  focus: () => void;
+}
+
+function createFakeElement(): FakeElement {
+  const classNames = new Set<string>();
+  const element: Omit<FakeElement, 'className'> = {
+    children: [],
+    style: {},
+    dataset: {},
+    textContent: '',
+    value: '',
+    checked: false,
+    disabled: false,
+    hidden: false,
+    type: '',
+    id: '',
+    htmlFor: '',
+    placeholder: '',
+    rows: 0,
+    step: '',
+    inputMode: '',
+    classList: {
+      add: (...tokens: string[]) => {
+        tokens.forEach((token) => classNames.add(token));
+      },
+      remove: (...tokens: string[]) => {
+        tokens.forEach((token) => classNames.delete(token));
+      },
+      toggle: (token: string, force?: boolean) => {
+        const shouldAdd = force ?? !classNames.has(token);
+        if (shouldAdd) {
+          classNames.add(token);
+        } else {
+          classNames.delete(token);
+        }
+        return shouldAdd;
+      },
+      contains: (token: string) => classNames.has(token)
+    },
+    appendChild: (child: FakeElement) => {
+      element.children.push(child);
+      return child;
+    },
+    append: (...children: FakeElement[]) => {
+      element.children.push(...children);
+    },
+    replaceChildren: (...children: FakeElement[]) => {
+      element.children = [...children];
+    },
+    insertBefore: (child: FakeElement, before: FakeElement | null) => {
+      const index = before ? element.children.indexOf(before) : -1;
+      if (index >= 0) {
+        element.children.splice(index, 0, child);
+      } else {
+        element.children.push(child);
+      }
+      return child;
+    },
+    remove: vi.fn(),
+    addEventListener: vi.fn(),
+    setAttribute: vi.fn(),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => []),
+    focus: vi.fn()
+  };
+
+  Object.defineProperty(element, 'className', {
+    get: () => Array.from(classNames).join(' '),
+    set: (value: string) => {
+      classNames.clear();
+      value
+        .split(/\s+/)
+        .filter(Boolean)
+        .forEach((token) => classNames.add(token));
+    }
+  });
+
+  return element as FakeElement;
+}
+
+function loadBuilderHelpers(): {
+  buildParameterJson: BuildParameterJson;
+  createRowsFromExistingParameter: CreateRowsFromExistingParameter;
+} {
+  const uiScriptPath = resolve(__dirname, '../../src/webviews/scriptRunner/ui/index.js');
+  const source = readFileSync(uiScriptPath, 'utf8');
+  const elements = new Map<string, FakeElement>();
+  const document = {
+    getElementById: (id: string) => {
+      let element = elements.get(id);
+      if (!element) {
+        element = createFakeElement();
+        element.id = id;
+        elements.set(id, element);
+      }
+      return element;
+    },
+    createElement: () => createFakeElement(),
+    querySelector: () => null,
+    querySelectorAll: () => []
+  };
+
+  const context = vm.createContext({
+    acquireVsCodeApi: () => ({
+      postMessage: vi.fn()
+    }),
+    document,
+    window: {
+      addEventListener: vi.fn()
+    }
+  });
+
+  new vm.Script(source, { filename: uiScriptPath }).runInContext(context);
+  const globals = context as Record<string, unknown>;
+  const buildParameterJson = globals.buildParameterJson;
+  const createRowsFromExistingParameter = globals.createRowsFromExistingParameter;
+
+  expect(buildParameterJson).toBeTypeOf('function');
+  expect(createRowsFromExistingParameter).toBeTypeOf('function');
+
+  return {
+    buildParameterJson: buildParameterJson as BuildParameterJson,
+    createRowsFromExistingParameter:
+      createRowsFromExistingParameter as CreateRowsFromExistingParameter
+  };
+}
+
+describe('script parameter JSON builder UI helpers', () => {
+  it('serializes string, number, boolean, and JSON rows into parseable JSON', () => {
+    const { buildParameterJson } = loadBuilderHelpers();
+
+    const result = buildParameterJson([
+      { key: 'name', type: 'string', value: 'Ada' },
+      { key: 'count', type: 'number', value: '42.5' },
+      { key: 'enabled', type: 'bool', value: 'true' },
+      { key: 'payload', type: 'json', value: '{"ids":[1,2],"mode":"sync"}' }
+    ]);
+
+    expect(result.error).toBe('');
+    expect(JSON.parse(result.json)).toEqual({
+      name: 'Ada',
+      count: 42.5,
+      enabled: true,
+      payload: {
+        ids: [1, 2],
+        mode: 'sync'
+      }
+    });
+  });
+
+  it('returns targeted validation errors for bad builder rows', () => {
+    const { buildParameterJson } = loadBuilderHelpers();
+
+    expect(
+      buildParameterJson([{ key: 'count', type: 'number', value: 'not-a-number' }])
+    ).toMatchObject({
+      json: '',
+      error: 'Row 1: enter a valid number.'
+    });
+    expect(
+      buildParameterJson([{ key: 'payload', type: 'json', value: '{"unterminated"' }])
+    ).toMatchObject({
+      json: '',
+      error: 'Row 1: enter valid JSON.'
+    });
+    expect(
+      buildParameterJson([
+        { key: 'id', type: 'string', value: '1' },
+        { key: 'id', type: 'number', value: '2' }
+      ])
+    ).toMatchObject({
+      json: '',
+      error: 'Row 2: key "id" is duplicated.'
+    });
+  });
+
+  it('hydrates rows from an existing JSON object with matching value types', () => {
+    const { createRowsFromExistingParameter } = loadBuilderHelpers();
+
+    expect(
+      createRowsFromExistingParameter(
+        JSON.stringify({
+          name: 'Ada',
+          count: 7,
+          enabled: false,
+          payload: { ids: [1, 2] },
+          blank: null
+        })
+      )
+    ).toEqual([
+      { key: 'name', type: 'string', value: 'Ada' },
+      { key: 'count', type: 'number', value: '7' },
+      { key: 'enabled', type: 'bool', value: 'false' },
+      { key: 'payload', type: 'json', value: '{\n  "ids": [\n    1,\n    2\n  ]\n}' },
+      { key: 'blank', type: 'json', value: 'null' }
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #180

## Summary
- Adds the Script Runner Build Parameter panel with key/value rows, per-row string/number/boolean/JSON inputs, duplicate-key and value validation, and live JSON preview.
- Adds `filemaker.scripts.parameterBuilder.enabled` with default `true` and hides the builder when disabled.
- Covers the builder serialization and hydration helpers with focused unit tests.

## Validation
- `GH_TOKEN="$(gh auth token)" ai-pipeline validate --id 180` -> passed; issue declares no `validation.local` commands.
- `npm run test -w extension -- scriptParameterBuilderUi.test.ts` -> 1 file, 3 tests passed.
- `npm run typecheck --workspaces --if-present` -> passed.
- `npm run lint --workspaces --if-present` -> passed.
- `npm test --workspaces --if-present` -> designer-ui 6 files/15 tests, runtime-next 3 files/9 tests, extension 79 files/449 tests passed.
- `npm run build -w shared && npm run build -w extension` -> passed.

## Notes
- `npm run format:check -w extension` currently reports pre-existing formatting drift across 120 files outside this scoped change.
- Optional Gemini local review could not run because Gemini CLI auth is not configured in this shell.