### PR TITLE
Container field upload support (#179)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -113,6 +113,7 @@ Credentials stay in VS Code `SecretStorage`; they are never written to workspace
 | `FileMaker: Open Record Editor` | Edit a record with preview support |
 | `FileMaker: Create Record` | Create a new record on a layout |
 | `FileMaker: Delete Record` | Delete a record with confirmation |
+| `FileMaker: Upload to Container` | Upload an image, PDF, or binary file to a container field |
 | `FileMaker: Capture Schema Snapshot` | Save metadata for later diffing |
 | `FileMaker: Diff Schema Snapshots` | Compare two snapshots side by side |
 | `FileMaker: Batch Export (Find)` | Export JSONL or CSV from a find request |

--- a/extension/docs/USER_GUIDE.md
+++ b/extension/docs/USER_GUIDE.md
@@ -210,6 +210,18 @@ Click on any layout to expand it and see its fields, value lists, and schema sna
 
 ---
 
+## Uploading to a Container Field
+
+1. Press `Cmd+Shift+P` / `Ctrl+Shift+P`.
+2. Type **FileMaker: Upload to Container** and select it, or click **Upload Container** from the Query Builder.
+3. Select a profile and layout.
+4. Enter the record ID and container field name.
+5. Pick the image, PDF, or other binary file to upload.
+
+The upload uses the FileMaker Data API container endpoint with a multipart part named `upload`. The default size cap is 100 MB. Change `filemaker.containerUploadMaxBytes` if your server and workflow need a different limit.
+
+---
+
 ## Running Scripts
 
 1. Press `Cmd+Shift+P` / `Ctrl+Shift+P`.

--- a/extension/package.json
+++ b/extension/package.json
@@ -293,6 +293,10 @@
         "title": "FileMaker: Delete Record"
       },
       {
+        "command": "filemakerDataApiTools.uploadContainer",
+        "title": "FileMaker: Upload to Container"
+      },
+      {
         "command": "filemakerDataApiTools.batchExportFind",
         "title": "FileMaker: Batch Export (Find)"
       },
@@ -495,6 +499,11 @@
           "group": "navigation@7"
         },
         {
+          "command": "filemakerDataApiTools.uploadContainer",
+          "when": "view == filemakerExplorer && viewItem == fmLayout",
+          "group": "navigation@8"
+        },
+        {
           "command": "filemakerDataApiTools.openSchemaSnapshotJson",
           "when": "view == filemakerExplorer && viewItem == fmSchemaSnapshot",
           "group": "inline@1"
@@ -569,6 +578,7 @@
         { "command": "filemakerDataApiTools.editRecordById", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.createRecord", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.deleteRecord", "when": "filemaker.hasProfiles" },
+        { "command": "filemakerDataApiTools.uploadContainer", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.batchExportFind", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.batchUpdateFromFile", "when": "filemaker.hasProfiles" },
         { "command": "filemakerDataApiTools.captureSchemaSnapshot", "when": "filemaker.hasProfiles" },
@@ -740,6 +750,13 @@
           "type": "boolean",
           "default": true,
           "description": "Enable record editor write-back features."
+        },
+        "filemaker.containerUploadMaxBytes": {
+          "type": "number",
+          "default": 104857600,
+          "minimum": 1,
+          "maximum": 2147483647,
+          "description": "Maximum file size, in bytes, allowed by FileMaker: Upload to Container. Default is 100 MB."
         },
         "filemaker.features.batch.enabled": {
           "type": "boolean",

--- a/extension/src/commands/recordEdit.ts
+++ b/extension/src/commands/recordEdit.ts
@@ -7,6 +7,7 @@ import type { ProfileStore } from '../services/profileStore';
 import type { SchemaService } from '../services/schemaService';
 import type { SettingsService } from '../services/settingsService';
 import { validateRecordId } from '../utils/jsonValidate';
+import { readContainerUploadFile } from '../utils/containerUpload';
 import { parseLayoutArg, pickProfile, promptForLayout, showCommandError } from './common';
 import { RecordEditorPanel } from '../webviews/recordEditor';
 
@@ -18,6 +19,16 @@ interface RegisterRecordEditCommandsDeps {
   settingsService: SettingsService;
   roleGuard: RoleGuard;
   logger: Logger;
+}
+
+interface ContainerUploadCommandArg {
+  profileId?: string;
+  layout?: string;
+  layoutName?: string;
+  recordId?: string;
+  fieldName?: string;
+  fieldRepetition?: number;
+  modId?: string;
 }
 
 export function registerRecordEditCommands(deps: RegisterRecordEditCommandsDeps): vscode.Disposable[] {
@@ -235,6 +246,145 @@ export function registerRecordEditCommands(deps: RegisterRecordEditCommandsDeps)
           logMessage: 'Delete record command failed.'
         });
       }
-    })
+    }),
+
+    vscode.commands.registerCommand(
+      'filemakerDataApiTools.uploadContainer',
+      async (arg: unknown) => {
+        if (!settingsService.isRecordEditEnabled()) {
+          vscode.window.showInformationMessage('Record editing is disabled by settings.');
+          return false;
+        }
+        if (!(await roleGuard.assertFeature('recordEdit', 'Upload to Container'))) {
+          return false;
+        }
+        if (!vscode.workspace.isTrusted) {
+          vscode.window.showWarningMessage(
+            'Upload to Container is disabled in untrusted workspaces.'
+          );
+          return false;
+        }
+
+        const contextArg = parseContainerUploadArg(arg);
+        let profileId = contextArg.profileId;
+        let layout = contextArg.layout;
+
+        if (!profileId) {
+          const profile = await pickProfile(profileStore, true);
+          if (!profile) {
+            return false;
+          }
+          profileId = profile.id;
+        }
+
+        const profile = await profileStore.getProfile(profileId);
+        if (!profile) {
+          vscode.window.showErrorMessage('Selected profile not found.');
+          return false;
+        }
+
+        if (!layout) {
+          layout = await promptForLayout(profile, fmClient);
+        }
+
+        if (!layout) {
+          return false;
+        }
+
+        const recordId = contextArg.recordId ?? (await promptForRecordId());
+        if (!recordId) {
+          return false;
+        }
+
+        const fieldName = contextArg.fieldName ?? (await promptForContainerFieldName());
+        if (!fieldName) {
+          return false;
+        }
+
+        const selection = await vscode.window.showOpenDialog({
+          title: 'Select File to Upload',
+          openLabel: 'Upload',
+          canSelectFiles: true,
+          canSelectFolders: false,
+          canSelectMany: false
+        });
+
+        const uri = selection?.[0];
+        if (!uri) {
+          return false;
+        }
+
+        try {
+          const maxBytes = settingsService.getContainerUploadMaxBytes();
+          const file = await readContainerUploadFile(uri, maxBytes);
+          const result = await fmClient.uploadContainer(
+            profile,
+            layout,
+            recordId.trim(),
+            fieldName.trim(),
+            file,
+            {
+              fieldRepetition: contextArg.fieldRepetition,
+              modId: contextArg.modId,
+              maxBytes
+            }
+          );
+
+          vscode.window.showInformationMessage(
+            `Uploaded "${file.fileName}" to ${fieldName.trim()} on record ${result.recordId}.`
+          );
+          return true;
+        } catch (error) {
+          await showCommandError(error, {
+            fallbackMessage: 'Failed to upload file to container field.',
+            logger,
+            logMessage: 'Upload container command failed.',
+            actions: {
+              settingsKey: 'filemaker.containerUploadMaxBytes'
+            }
+          });
+          return false;
+        }
+      }
+    )
   ];
+}
+
+function parseContainerUploadArg(arg: unknown): ContainerUploadCommandArg {
+  const layoutArg = parseLayoutArg(arg);
+  if (!arg || typeof arg !== 'object') {
+    return layoutArg;
+  }
+
+  const value = arg as ContainerUploadCommandArg;
+  return {
+    ...layoutArg,
+    recordId: typeof value.recordId === 'string' ? value.recordId : undefined,
+    fieldName: typeof value.fieldName === 'string' ? value.fieldName : undefined,
+    fieldRepetition: typeof value.fieldRepetition === 'number' ? value.fieldRepetition : undefined,
+    modId: typeof value.modId === 'string' ? value.modId : undefined
+  };
+}
+
+async function promptForRecordId(): Promise<string | undefined> {
+  const recordId = await vscode.window.showInputBox({
+    title: 'Upload to Container',
+    prompt: 'Enter the FileMaker record ID',
+    ignoreFocusOut: true,
+    validateInput: (value) => validateRecordId(value).error
+  });
+
+  return recordId?.trim() || undefined;
+}
+
+async function promptForContainerFieldName(): Promise<string | undefined> {
+  const fieldName = await vscode.window.showInputBox({
+    title: 'Upload to Container',
+    prompt: 'Enter the container field name',
+    ignoreFocusOut: true,
+    validateInput: (value) =>
+      value.trim().length === 0 ? 'Container field name is required.' : undefined
+  });
+
+  return fieldName?.trim() || undefined;
 }

--- a/extension/src/services/fmClient.ts
+++ b/extension/src/services/fmClient.ts
@@ -4,6 +4,7 @@ import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig } f
 
 import type {
   ConnectionProfile,
+  ContainerUploadFile,
   EditRecordResult,
   FileMakerRecord,
   FindRecordsRequest,
@@ -62,6 +63,13 @@ interface RequestTrace {
 
 interface ClientRequestControl {
   signal?: AbortSignal;
+}
+
+export interface FMClientContainerUploadOptions {
+  signal?: AbortSignal;
+  fieldRepetition?: number;
+  modId?: string;
+  maxBytes?: number;
 }
 
 const DEFAULT_LAYOUT_TTL_MS = 60_000;
@@ -658,6 +666,108 @@ export class FMClient {
     );
   }
 
+  public async uploadContainer(
+    profile: ConnectionProfile,
+    layout: string,
+    recordId: string,
+    fieldName: string,
+    file: ContainerUploadFile,
+    options?: FMClientContainerUploadOptions
+  ): Promise<EditRecordResult> {
+    const normalizedLayout = layout.trim();
+    const normalizedRecordId = recordId.trim();
+    const normalizedFieldName = fieldName.trim();
+    const normalizedFileName = file.fileName.trim();
+    const content = normalizeUploadContent(file.content);
+
+    if (!normalizedLayout) {
+      throw new FMClientError('Layout is required to upload container data.');
+    }
+    if (!normalizedRecordId) {
+      throw new FMClientError('Record ID is required to upload container data.');
+    }
+    if (!normalizedFieldName) {
+      throw new FMClientError('Container field name is required.');
+    }
+    if (!normalizedFileName) {
+      throw new FMClientError('Upload file name is required.');
+    }
+    if (content.byteLength === 0) {
+      throw new FMClientError('Upload file is empty.');
+    }
+    if (options?.maxBytes !== undefined && content.byteLength > options.maxBytes) {
+      throw new FMClientError(
+        `Container upload exceeds the configured limit (${content.byteLength} > ${options.maxBytes} bytes).`,
+        {
+          code: 'CONTAINER_UPLOAD_TOO_LARGE',
+          details: {
+            actualBytes: content.byteLength,
+            maxBytes: options.maxBytes
+          }
+        }
+      );
+    }
+
+    const fieldRepetition = normalizeContainerFieldRepetition(options?.fieldRepetition);
+    const uploadFile = {
+      ...file,
+      fileName: normalizedFileName,
+      content
+    };
+
+    return this.withHistory(
+      {
+        profileId: profile.id,
+        operation: 'uploadContainer',
+        layout: normalizedLayout,
+        endpoint: `POST /layouts/${normalizedLayout}/records/${normalizedRecordId}/containers/${normalizedFieldName}/${fieldRepetition}`
+      },
+      async (trace) => {
+        if (isProxyProfile(profile)) {
+          return this.proxyClient.uploadContainer(
+            profile,
+            normalizedLayout,
+            normalizedRecordId,
+            normalizedFieldName,
+            uploadFile,
+            {
+              fieldRepetition,
+              modId: options?.modId,
+              signal: options?.signal
+            }
+          );
+        }
+
+        const multipart = buildContainerUploadMultipart(uploadFile);
+        const envelope = await this.requestWithAuth<Record<string, unknown>>(
+          profile,
+          {
+            method: 'POST',
+            path:
+              `/layouts/${encodeURIComponent(normalizedLayout)}` +
+              `/records/${encodeURIComponent(normalizedRecordId)}` +
+              `/containers/${encodeURIComponent(normalizedFieldName)}/${fieldRepetition}`,
+            data: multipart.body,
+            headers: {
+              'Content-Type': multipart.contentType,
+              'Content-Length': String(multipart.body.byteLength)
+            },
+            params: options?.modId ? { modId: options.modId } : undefined,
+            signal: options?.signal
+          },
+          true,
+          trace
+        );
+
+        return {
+          recordId: normalizedRecordId,
+          messages: envelope.messages,
+          response: envelope.response
+        };
+      }
+    );
+  }
+
   public async runScript(
     profile: ConnectionProfile,
     request: RunScriptRequest,
@@ -853,7 +963,8 @@ export class FMClient {
         data: request.data,
         params: request.params,
         signal: request.signal,
-        timeout: this.timeoutMs
+        timeout: this.timeoutMs,
+        maxBodyLength: Infinity
       };
 
       const response = await this.httpClient.request<DataApiEnvelope<TResponse>>(config);
@@ -915,6 +1026,7 @@ export class FMClient {
         params: request.params,
         signal: request.signal,
         timeout: this.timeoutMs,
+        maxBodyLength: Infinity,
         validateStatus: (status) => (status >= 200 && status < 300) || status === 304
       };
 
@@ -1148,6 +1260,52 @@ function buildScriptParams(
   }
 
   return params;
+}
+
+function normalizeUploadContent(content: Buffer | Uint8Array): Buffer {
+  return Buffer.isBuffer(content) ? content : Buffer.from(content);
+}
+
+function normalizeContainerFieldRepetition(fieldRepetition: number | undefined): number {
+  if (fieldRepetition === undefined) {
+    return 1;
+  }
+
+  if (!Number.isInteger(fieldRepetition) || fieldRepetition < 1) {
+    throw new FMClientError('Container field repetition must be a positive integer.');
+  }
+
+  return fieldRepetition;
+}
+
+function buildContainerUploadMultipart(file: ContainerUploadFile & { content: Buffer }): {
+  body: Buffer;
+  contentType: string;
+} {
+  const boundary = `----filemaker-data-api-tools-${randomUUID()}`;
+  const contentType = sanitizeMultipartHeaderValue(file.contentType ?? 'application/octet-stream');
+  const fileName = sanitizeMultipartHeaderValue(file.fileName);
+
+  const header = Buffer.from(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="upload"; filename="${fileName}"\r\n` +
+      `Content-Type: ${contentType}\r\n\r\n`,
+    'utf8'
+  );
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+
+  return {
+    body: Buffer.concat([header, file.content, footer]),
+    contentType: `multipart/form-data; boundary=${boundary}`
+  };
+}
+
+function sanitizeMultipartHeaderValue(value: string): string {
+  const normalized = value
+    .replace(/[\r\n"]/g, '_')
+    .replace(/\\/g, '\\\\')
+    .trim();
+  return normalized.length > 0 ? normalized : 'application/octet-stream';
 }
 
 function isLikelyScriptUnsupportedError(error: unknown): boolean {

--- a/extension/src/services/proxyClient.ts
+++ b/extension/src/services/proxyClient.ts
@@ -5,6 +5,7 @@ import { FMClientError, toFMClientError } from './errors';
 import type { SecretStore } from './secretStore';
 import type {
   ConnectionProfile,
+  ContainerUploadFile,
   EditRecordResult,
   FileMakerRecord,
   FindRecordsRequest,
@@ -59,6 +60,16 @@ interface ProxyCreateRecordResponse {
 
 interface ProxyDeleteRecordResponse {
   result?: EditRecordResult;
+}
+
+interface ProxyUploadContainerResponse {
+  result?: EditRecordResult;
+}
+
+export interface ProxyUploadContainerOptions {
+  signal?: AbortSignal;
+  fieldRepetition?: number;
+  modId?: string;
 }
 
 export class ProxyClient {
@@ -220,6 +231,37 @@ export class ProxyClient {
 
     if (!data.result) {
       throw new FMClientError('Proxy response did not include a deleteRecord result payload.');
+    }
+
+    return data.result;
+  }
+
+  public async uploadContainer(
+    profile: ConnectionProfile,
+    layout: string,
+    recordId: string,
+    fieldName: string,
+    file: ContainerUploadFile,
+    options?: ProxyUploadContainerOptions
+  ): Promise<EditRecordResult> {
+    const data = await this.invoke<ProxyUploadContainerResponse>(
+      profile,
+      'uploadContainer',
+      {
+        layout,
+        recordId,
+        fieldName,
+        fieldRepetition: options?.fieldRepetition ?? 1,
+        modId: options?.modId,
+        fileName: file.fileName,
+        contentType: file.contentType ?? 'application/octet-stream',
+        contentBase64: Buffer.from(file.content).toString('base64')
+      },
+      options?.signal
+    );
+
+    if (!data.result) {
+      throw new FMClientError('Proxy response did not include an uploadContainer result payload.');
     }
 
     return data.result;

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import type { EnterpriseRole, PerformanceMode, SavedQueryScope, SchemaSnapshotStorage } from '../types/fm';
 import type { LogLevel } from './logger';
 import type { SecretFallbackMode } from './secretStore';
+import { DEFAULT_CONTAINER_UPLOAD_MAX_BYTES, normalizeContainerUploadMaxBytes } from '../utils/containerUpload';
 
 /**
  * Lazily computed allow-list of crypto hash algorithms available on this Node
@@ -238,6 +239,15 @@ export class SettingsService {
 
   public isBatchEnabled(): boolean {
     return this.getConfiguration('filemaker').get<boolean>('features.batch.enabled', true);
+  }
+
+  public getContainerUploadMaxBytes(): number {
+    return normalizeContainerUploadMaxBytes(
+      this.getConfiguration('filemaker').get<number>(
+        'containerUploadMaxBytes',
+        DEFAULT_CONTAINER_UPLOAD_MAX_BYTES
+      )
+    );
   }
 
   public isEnterpriseModeEnabled(): boolean {

--- a/extension/src/types/fm.ts
+++ b/extension/src/types/fm.ts
@@ -60,6 +60,12 @@ export interface EditRecordResult {
   response: Record<string, unknown>;
 }
 
+export interface ContainerUploadFile {
+  fileName: string;
+  content: Buffer | Uint8Array;
+  contentType?: string;
+}
+
 export interface SavedQuery {
   id: string;
   name: string;

--- a/extension/src/utils/containerUpload.ts
+++ b/extension/src/utils/containerUpload.ts
@@ -1,0 +1,112 @@
+import * as path from 'path';
+
+import * as vscode from 'vscode';
+
+import { FMClientError } from '../services/errors';
+import type { ContainerUploadFile } from '../types/fm';
+
+export const DEFAULT_CONTAINER_UPLOAD_MAX_BYTES = 100 * 1024 * 1024;
+const MAX_CONTAINER_UPLOAD_MAX_BYTES = 2_147_483_647;
+
+const CONTENT_TYPES_BY_EXTENSION: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.bmp': 'image/bmp',
+  '.gif': 'image/gif',
+  '.heic': 'image/heic',
+  '.heif': 'image/heif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.tif': 'image/tiff',
+  '.tiff': 'image/tiff',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp'
+};
+
+export function normalizeContainerUploadMaxBytes(configured: unknown): number {
+  if (typeof configured !== 'number' || !Number.isFinite(configured)) {
+    return DEFAULT_CONTAINER_UPLOAD_MAX_BYTES;
+  }
+
+  return clamp(Math.round(configured), 1, MAX_CONTAINER_UPLOAD_MAX_BYTES);
+}
+
+export async function readContainerUploadFile(
+  uri: vscode.Uri,
+  maxBytes: number
+): Promise<ContainerUploadFile> {
+  const normalizedMaxBytes = normalizeContainerUploadMaxBytes(maxBytes);
+  const stat = await vscode.workspace.fs.stat(uri);
+
+  if (stat.size > normalizedMaxBytes) {
+    throw createContainerUploadTooLargeError(stat.size, normalizedMaxBytes);
+  }
+
+  const content = await vscode.workspace.fs.readFile(uri);
+  if (content.byteLength > normalizedMaxBytes) {
+    throw createContainerUploadTooLargeError(content.byteLength, normalizedMaxBytes);
+  }
+
+  const fileName = resolveFileName(uri);
+
+  return {
+    fileName,
+    content,
+    contentType: detectContainerUploadContentType(fileName)
+  };
+}
+
+export function detectContainerUploadContentType(fileName: string): string {
+  const extension = path.extname(fileName).toLowerCase();
+  return CONTENT_TYPES_BY_EXTENSION[extension] ?? 'application/octet-stream';
+}
+
+export function createContainerUploadTooLargeError(
+  actualBytes: number,
+  maxBytes: number
+): FMClientError {
+  return new FMClientError(
+    `Container upload is ${formatBytes(actualBytes)}, which exceeds the configured limit of ${formatBytes(maxBytes)}.`,
+    {
+      code: 'CONTAINER_UPLOAD_TOO_LARGE',
+      details: {
+        actualBytes,
+        maxBytes
+      }
+    }
+  );
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${formatNumber(kib)} KB`;
+  }
+
+  const mib = kib / 1024;
+  if (mib < 1024) {
+    return `${formatNumber(mib)} MB`;
+  }
+
+  return `${formatNumber(mib / 1024)} GB`;
+}
+
+function resolveFileName(uri: vscode.Uri): string {
+  const candidate = uri.fsPath || uri.path || 'upload';
+  const fileName = path.basename(candidate);
+  return fileName.trim() || 'upload';
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/extension/src/webviews/queryBuilder/index.ts
+++ b/extension/src/webviews/queryBuilder/index.ts
@@ -43,6 +43,11 @@ interface CopySnippetPayload extends RunQueryPayload {
   includeAuthHeader?: boolean;
 }
 
+interface UploadContainerPayload {
+  profileId: string;
+  layout: string;
+}
+
 interface QueryExecutionResult {
   profileId: string;
   layout: string;
@@ -64,6 +69,7 @@ type IncomingMessage =
   | { type: 'exportResultsCsvFile' }
   | { type: 'copyFetchSnippet'; payload: CopySnippetPayload }
   | { type: 'copyCurlSnippet'; payload: CopySnippetPayload }
+  | { type: 'uploadContainer'; payload: UploadContainerPayload }
   | { type: 'refreshHistory' };
 
 export class QueryBuilderPanel {
@@ -185,6 +191,9 @@ export class QueryBuilderPanel {
         break;
       case 'copyCurlSnippet':
         await this.copyCurlSnippet(message.payload);
+        break;
+      case 'uploadContainer':
+        await this.uploadContainer(message.payload);
         break;
       case 'refreshHistory':
         await this.sendHistory();
@@ -519,6 +528,24 @@ export class QueryBuilderPanel {
     }
   }
 
+  private async uploadContainer(payload: UploadContainerPayload): Promise<void> {
+    try {
+      const completed = await vscode.commands.executeCommand<boolean>(
+        'filemakerDataApiTools.uploadContainer',
+        payload
+      );
+
+      await this.panel.webview.postMessage({
+        type: 'containerUploadResult',
+        payload: {
+          completed: completed === true
+        }
+      });
+    } catch (error) {
+      await this.postError(this.formatError(error));
+    }
+  }
+
   private toFindSnippetRequest(
     profile: ConnectionProfile,
     layout: string,
@@ -658,6 +685,17 @@ export class QueryBuilderPanel {
           payload
         };
       }
+      case 'uploadContainer': {
+        const payload = this.parseUploadContainerPayload(value.payload);
+        if (!payload) {
+          return undefined;
+        }
+
+        return {
+          type,
+          payload
+        };
+      }
       default:
         return undefined;
     }
@@ -720,6 +758,24 @@ export class QueryBuilderPanel {
     return {
       ...payload,
       includeAuthHeader: raw ? getOptionalBooleanField(raw, 'includeAuthHeader') : undefined
+    };
+  }
+
+  private parseUploadContainerPayload(rawPayload: unknown): UploadContainerPayload | undefined {
+    const payload = toRecord(rawPayload);
+    if (!payload) {
+      return undefined;
+    }
+
+    const profileId = getStringField(payload, 'profileId');
+    const layout = getStringField(payload, 'layout');
+    if (!profileId || !layout) {
+      return undefined;
+    }
+
+    return {
+      profileId,
+      layout
     };
   }
 
@@ -795,6 +851,7 @@ export class QueryBuilderPanel {
         <button id="exportCsvButton">Export CSV File</button>
         <button id="copyFetchButton">Copy as fetch()</button>
         <button id="copyCurlButton">Copy as curl</button>
+        <button id="uploadContainerButton">Upload Container</button>
       </div>
       <div class="saved">
         <label for="savedQueriesSelect">Saved Queries</label>

--- a/extension/src/webviews/queryBuilder/ui/index.js
+++ b/extension/src/webviews/queryBuilder/ui/index.js
@@ -27,6 +27,7 @@ const exportJsonButton = document.getElementById('exportJsonButton');
 const exportCsvButton = document.getElementById('exportCsvButton');
 const copyFetchButton = document.getElementById('copyFetchButton');
 const copyCurlButton = document.getElementById('copyCurlButton');
+const uploadContainerButton = document.getElementById('uploadContainerButton');
 const savedQueriesSelect = document.getElementById('savedQueriesSelect');
 const loadSavedButton = document.getElementById('loadSavedButton');
 const prevButton = document.getElementById('prevButton');
@@ -86,6 +87,13 @@ window.addEventListener('message', (event) => {
       break;
     case 'saveCurrentQuery':
       saveButton.click();
+      break;
+    case 'containerUploadResult':
+      setStatus(
+        message.payload && message.payload.completed
+          ? 'Container upload completed.'
+          : 'Container upload cancelled.'
+      );
       break;
     case 'error':
       setStatus(message.message || 'Unknown error.', true);
@@ -180,6 +188,19 @@ copyCurlButton.addEventListener('click', () => {
       ...payload,
       includeAuthHeader: includeAuthCheckbox.checked
     }
+  });
+});
+
+uploadContainerButton.addEventListener('click', () => {
+  const payload = collectProfileLayoutPayload();
+  if (!payload) {
+    return;
+  }
+
+  setStatus('Opening container upload...');
+  vscode.postMessage({
+    type: 'uploadContainer',
+    payload
   });
 });
 
@@ -328,6 +349,22 @@ function requestLayouts(profileId, preferredLayout) {
 }
 
 function collectPayload() {
+  const base = collectProfileLayoutPayload();
+  if (!base) {
+    return undefined;
+  }
+
+  return {
+    ...base,
+    findJson: findJson.value,
+    sortJson: sortJson.value,
+    limit: parseNumber(limitInput.value),
+    offset: parseNumber(offsetInput.value),
+    queryId: state.currentQueryId
+  };
+}
+
+function collectProfileLayoutPayload() {
   const profileId = profileSelect.value;
   const layout = layoutSelect.value;
 
@@ -343,12 +380,7 @@ function collectPayload() {
 
   return {
     profileId,
-    layout,
-    findJson: findJson.value,
-    sortJson: sortJson.value,
-    limit: parseNumber(limitInput.value),
-    offset: parseNumber(offsetInput.value),
-    queryId: state.currentQueryId
+    layout
   };
 }
 
@@ -688,7 +720,8 @@ function updateResultRowState(rowState, record, columns) {
     rowState.idCell.textContent = nextRecordId;
   }
 
-  const fieldData = record.fieldData && typeof record.fieldData === 'object' ? record.fieldData : {};
+  const fieldData =
+    record.fieldData && typeof record.fieldData === 'object' ? record.fieldData : {};
   columns.forEach((column) => {
     const cell = rowState.cells.get(column);
     const nextValue = toCellValue(fieldData[column]);
@@ -701,12 +734,18 @@ function updateResultRowState(rowState, record, columns) {
 function createStableRowKeys(records) {
   const counts = new Map();
   records.forEach((record) => {
-    const recordId = record && record.recordId !== undefined && record.recordId !== null ? String(record.recordId) : '';
+    const recordId =
+      record && record.recordId !== undefined && record.recordId !== null
+        ? String(record.recordId)
+        : '';
     counts.set(recordId, (counts.get(recordId) || 0) + 1);
   });
 
   return records.map((record, index) => {
-    const recordId = record && record.recordId !== undefined && record.recordId !== null ? String(record.recordId) : '';
+    const recordId =
+      record && record.recordId !== undefined && record.recordId !== null
+        ? String(record.recordId)
+        : '';
     if (!recordId || counts.get(recordId) > 1) {
       return `row-${index}`;
     }

--- a/extension/test/unit/commands/containerUpload.test.ts
+++ b/extension/test/unit/commands/containerUpload.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import * as vscode from 'vscode';
+
+import { registerRecordEditCommands } from '../../../src/commands/recordEdit';
+import type { ConnectionProfile } from '../../../src/types/fm';
+
+function profile(): ConnectionProfile {
+  return {
+    id: 'profile-1',
+    name: 'Dev',
+    authMode: 'direct',
+    serverUrl: 'https://fm.example.com',
+    database: 'TestDB'
+  };
+}
+
+function createDeps() {
+  const uploadContainer = vi.fn().mockResolvedValue({
+    recordId: '42',
+    messages: [{ code: '0', message: 'OK' }],
+    response: {}
+  });
+
+  return {
+    context: {
+      subscriptions: [],
+      extensionUri: { fsPath: '/ext' }
+    } as unknown as vscode.ExtensionContext,
+    profileStore: {
+      getProfile: vi.fn().mockResolvedValue(profile()),
+      listProfiles: vi.fn().mockResolvedValue([profile()]),
+      getActiveProfileId: vi.fn().mockReturnValue('profile-1')
+    } as never,
+    fmClient: {
+      listLayouts: vi.fn().mockResolvedValue(['Contacts']),
+      uploadContainer
+    } as never,
+    schemaService: {} as never,
+    settingsService: {
+      isRecordEditEnabled: vi.fn().mockReturnValue(true),
+      getContainerUploadMaxBytes: vi.fn().mockReturnValue(4)
+    } as never,
+    roleGuard: {
+      assertFeature: vi.fn().mockResolvedValue(true)
+    } as never,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    } as never,
+    uploadContainer
+  };
+}
+
+describe('Upload to Container command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const fsMock = vscode.workspace.fs as unknown as {
+      stat: ReturnType<typeof vi.fn>;
+      readFile: ReturnType<typeof vi.fn>;
+    };
+    fsMock.stat = vi.fn().mockResolvedValue({ size: 4 });
+    fsMock.readFile.mockResolvedValue(Buffer.from('data'));
+    vi.mocked(vscode.window.showOpenDialog).mockResolvedValue([
+      {
+        fsPath: '/tmp/report.pdf',
+        path: '/tmp/report.pdf'
+      } as vscode.Uri
+    ]);
+  });
+
+  it('reads the selected file and passes the configured max bytes to FMClient', async () => {
+    const deps = createDeps();
+    registerRecordEditCommands(deps);
+
+    const uploadCommand = vi
+      .mocked(vscode.commands.registerCommand)
+      .mock.calls.find(([name]) => name === 'filemakerDataApiTools.uploadContainer')?.[1] as (
+      arg: unknown
+    ) => Promise<boolean>;
+
+    await expect(
+      uploadCommand({
+        profileId: 'profile-1',
+        layout: 'Contacts',
+        recordId: '42',
+        fieldName: 'Attachment'
+      })
+    ).resolves.toBe(true);
+
+    expect(deps.uploadContainer).toHaveBeenCalledWith(
+      profile(),
+      'Contacts',
+      '42',
+      'Attachment',
+      {
+        fileName: 'report.pdf',
+        content: Buffer.from('data'),
+        contentType: 'application/pdf'
+      },
+      {
+        fieldRepetition: undefined,
+        modId: undefined,
+        maxBytes: 4
+      }
+    );
+  });
+});

--- a/extension/test/unit/fmClient.test.ts
+++ b/extension/test/unit/fmClient.test.ts
@@ -101,7 +101,9 @@ describe('FMClient (unit)', () => {
 
     const client = new FMClient(secretStore, logger, 15_000, axios as never);
 
-    await expect(client.listLayouts(profile)).rejects.toThrow('FileMaker API error (HTTP 500) [500]');
+    await expect(client.listLayouts(profile)).rejects.toThrow(
+      'FileMaker API error (HTTP 500) [500]'
+    );
   });
 
   it('re-authenticates once on 401 and retries request', async () => {
@@ -158,5 +160,99 @@ describe('FMClient (unit)', () => {
     await expect(client.listLayouts(profile)).resolves.toEqual(['Contacts']);
     await expect(secretStore.getSessionToken(profile.id)).resolves.toBe('new-token');
     expect(axios.request).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    ['image upload', 'photo.png', 'image/png'],
+    ['PDF upload', 'report.pdf', 'application/pdf'],
+    ['binary upload', 'archive.bin', 'application/octet-stream']
+  ])(
+    'uploads container data as multipart form-data for %s',
+    async (_label, fileName, contentType) => {
+      const axios = new FakeAxios();
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn()
+      };
+      const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+      const profile = createProfile();
+
+      await secretStore.setSessionToken(profile.id, 'token-a');
+
+      axios.request.mockResolvedValueOnce({
+        data: {
+          response: {},
+          messages: [{ code: '0', message: 'OK' }]
+        }
+      } as AxiosResponse<Record<string, unknown>>);
+
+      const client = new FMClient(secretStore, logger, 15_000, axios as never);
+      const result = await client.uploadContainer(
+        profile,
+        'Contacts',
+        '42',
+        'Attachment',
+        {
+          fileName,
+          content: Buffer.from(`content:${fileName}`, 'utf8'),
+          contentType
+        },
+        {
+          maxBytes: 1024
+        }
+      );
+
+      expect(result.recordId).toBe('42');
+      expect(axios.request).toHaveBeenCalledTimes(1);
+
+      const uploadRequest = axios.request.mock.calls[0]?.[0] as Record<string, unknown>;
+      const headers = uploadRequest.headers as Record<string, string>;
+      const body = uploadRequest.data as Buffer;
+
+      expect(String(uploadRequest.url)).toContain(
+        '/fmi/data/vLatest/databases/TestDB/layouts/Contacts/records/42/containers/Attachment/1'
+      );
+      expect(headers.Authorization).toBe('Bearer token-a');
+      expect(headers['Content-Type']).toMatch(/^multipart\/form-data; boundary=/);
+      expect(headers['Content-Length']).toBe(String(body.byteLength));
+      expect(body.toString('utf8')).toContain('name="upload"');
+      expect(body.toString('utf8')).toContain(`filename="${fileName}"`);
+      expect(body.toString('utf8')).toContain(`Content-Type: ${contentType}`);
+      expect(body.toString('utf8')).toContain(`content:${fileName}`);
+    }
+  );
+
+  it('rejects container uploads larger than the configured limit before sending a request', async () => {
+    const axios = new FakeAxios();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+    const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+    const profile = createProfile();
+    const client = new FMClient(secretStore, logger, 15_000, axios as never);
+
+    await expect(
+      client.uploadContainer(
+        profile,
+        'Contacts',
+        '42',
+        'Attachment',
+        {
+          fileName: 'too-large.bin',
+          content: Buffer.alloc(11),
+          contentType: 'application/octet-stream'
+        },
+        {
+          maxBytes: 10
+        }
+      )
+    ).rejects.toThrow('Container upload exceeds the configured limit');
+
+    expect(axios.request).not.toHaveBeenCalled();
   });
 });

--- a/extension/test/unit/proxyClient.test.ts
+++ b/extension/test/unit/proxyClient.test.ts
@@ -159,7 +159,9 @@ describe('ProxyClient', () => {
         .reply(200, { ok: true, data: { result: editResult } });
 
       const client = createClient();
-      const result = await client.editRecord(createProfile(), 'Contacts', '42', { Name: 'Updated' });
+      const result = await client.editRecord(createProfile(), 'Contacts', '42', {
+        Name: 'Updated'
+      });
 
       expect(result.recordId).toBe('42');
       expect(result.modId).toBe('2');
@@ -203,9 +205,9 @@ describe('ProxyClient', () => {
   describe('missing proxy endpoint', () => {
     it('throws when proxy endpoint is missing', async () => {
       const client = createClient();
-      await expect(
-        client.createSession(createProfile({ proxyEndpoint: '' }))
-      ).rejects.toThrow('Proxy mode requires a proxy endpoint');
+      await expect(client.createSession(createProfile({ proxyEndpoint: '' }))).rejects.toThrow(
+        'Proxy mode requires a proxy endpoint'
+      );
     });
   });
 
@@ -242,6 +244,41 @@ describe('ProxyClient', () => {
 
       const client = createClient();
       const result = await client.deleteRecord(createProfile(), 'Contacts', '42');
+
+      expect(result.recordId).toBe('42');
+      scope.done();
+    });
+  });
+
+  describe('uploadContainer', () => {
+    it('sends base64 file content to the proxy action', async () => {
+      const uploadResult = {
+        recordId: '42',
+        messages: [{ code: '0', message: 'OK' }],
+        response: {}
+      };
+      const scope = nock(PROXY_URL)
+        .post(PROXY_PATH, (body: Record<string, unknown>) => {
+          const payload = body.payload as Record<string, unknown>;
+          return (
+            body.action === 'uploadContainer' &&
+            payload.layout === 'Contacts' &&
+            payload.recordId === '42' &&
+            payload.fieldName === 'Attachment' &&
+            payload.fieldRepetition === 1 &&
+            payload.fileName === 'report.pdf' &&
+            payload.contentType === 'application/pdf' &&
+            payload.contentBase64 === Buffer.from('pdf-bytes').toString('base64')
+          );
+        })
+        .reply(200, { ok: true, data: { result: uploadResult } });
+
+      const client = createClient();
+      const result = await client.uploadContainer(createProfile(), 'Contacts', '42', 'Attachment', {
+        fileName: 'report.pdf',
+        contentType: 'application/pdf',
+        content: Buffer.from('pdf-bytes')
+      });
 
       expect(result.recordId).toBe('42');
       scope.done();

--- a/extension/test/unit/settingsService.test.ts
+++ b/extension/test/unit/settingsService.test.ts
@@ -11,7 +11,7 @@ function createSettings(overrides?: ConfigMap, trusted = true): SettingsService 
     getConfiguration: (section?: string) =>
       ({
         get: <T>(key: string, defaultValue?: T): T => {
-          const sectionData = section ? data[section] ?? {} : {};
+          const sectionData = section ? (data[section] ?? {}) : {};
           const value = sectionData[key] as T | undefined;
           return value ?? (defaultValue as T);
         },
@@ -19,7 +19,7 @@ function createSettings(overrides?: ConfigMap, trusted = true): SettingsService 
         // can distinguish "explicitly set" from "default" in this mock. We treat any
         // present key as workspace-scoped because the test ConfigMap doesn't model scopes.
         inspect: <T>(key: string) => {
-          const sectionData = section ? data[section] ?? {} : {};
+          const sectionData = section ? (data[section] ?? {}) : {};
           const value = sectionData[key] as T | undefined;
           return {
             key,
@@ -41,6 +41,7 @@ describe('SettingsService', () => {
     expect(settings.getRequestTimeoutMs()).toBe(15_000);
     expect(settings.getSavedQueriesScope()).toBe('workspace');
     expect(settings.getTypegenOutputDir()).toBe('filemaker-types');
+    expect(settings.getContainerUploadMaxBytes()).toBe(100 * 1024 * 1024);
   });
 
   it('normalizes invalid values', () => {
@@ -49,6 +50,7 @@ describe('SettingsService', () => {
         'logging.level': 'verbose',
         'savedQueries.scope': 'bad',
         'batch.concurrency': 99,
+        containerUploadMaxBytes: 0,
         'typegen.outputDir': '../outside'
       },
       filemakerDataApiTools: {
@@ -61,6 +63,17 @@ describe('SettingsService', () => {
     expect(settings.getBatchConcurrency()).toBe(10);
     expect(settings.getRequestTimeoutMs()).toBe(1_000);
     expect(settings.getTypegenOutputDir()).toBe('filemaker-types');
+    expect(settings.getContainerUploadMaxBytes()).toBe(1);
+  });
+
+  it('clamps container upload max bytes to a safe upper bound', () => {
+    const settings = createSettings({
+      filemaker: {
+        containerUploadMaxBytes: Number.MAX_SAFE_INTEGER
+      }
+    });
+
+    expect(settings.getContainerUploadMaxBytes()).toBe(2_147_483_647);
   });
 
   it('forces workspaceState storage in untrusted workspaces', () => {


### PR DESCRIPTION
Closes #179

## Summary
- add FMClient and proxy-mode container upload support using multipart/form-data with the FileMaker `upload` part
- add FileMaker: Upload to Container command, Query Builder upload trigger, and `filemaker.containerUploadMaxBytes` setting
- document the workflow and cover direct/proxy uploads, settings, and command behavior with focused tests

## Validation
- `GH_TOKEN=$(gh auth token) ai-pipeline validate --id 179 --continue` (no validation.local commands declared)
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run package:check`
- `git diff --check`
