### PR TITLE
Move schema diff computation to a worker thread (#174)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -896,9 +896,10 @@
   "scripts": {
     "clean": "rimraf dist",
     "bundle:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap=inline --outfile=dist/extension.js",
+    "bundle:schema-diff-worker": "esbuild src/services/schemaDiffWorker.ts --bundle --platform=node --format=cjs --external:vscode --sourcemap=inline --outfile=dist/schemaDiffWorker.js",
     "build:designer-ui": "node ./scripts/build-designer-ui-if-available.mjs",
     "copy:webviews": "shx mkdir -p dist/webviews/queryBuilder/ui dist/webviews/recordViewer/ui dist/webviews/scriptRunner/ui dist/webviews/schemaDiff/ui dist/webviews/recordEditor/ui dist/webviews/connectionWizard/ui dist/webviews/layoutMode/ui && shx cp -r src/webviews/queryBuilder/ui/* dist/webviews/queryBuilder/ui && shx cp -r src/webviews/recordViewer/ui/* dist/webviews/recordViewer/ui && shx cp -r src/webviews/scriptRunner/ui/* dist/webviews/scriptRunner/ui && shx cp -r src/webviews/schemaDiff/ui/* dist/webviews/schemaDiff/ui && shx cp -r src/webviews/recordEditor/ui/* dist/webviews/recordEditor/ui && shx cp -r src/webviews/connectionWizard/ui/* dist/webviews/connectionWizard/ui && shx cp -r src/webviews/layoutMode/ui/* dist/webviews/layoutMode/ui && sh -c 'if [ -d ../designer-ui/dist ]; then shx cp -r ../designer-ui/dist/* dist/webviews/layoutMode/ui; fi'",
-    "build": "npm run build:designer-ui && npm run clean && npm run bundle:extension && npm run copy:webviews",
+    "build": "npm run build:designer-ui && npm run clean && npm run bundle:extension && npm run bundle:schema-diff-worker && npm run copy:webviews",
     "watch": "tsc -w -p .",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" --max-warnings=0",
     "format": "prettier --write \"**/*.{ts,js,json,md,css,html}\"",

--- a/extension/src/commands/schemaSnapshots.ts
+++ b/extension/src/commands/schemaSnapshots.ts
@@ -1,14 +1,18 @@
 import * as vscode from 'vscode';
 
 import type { FMClient } from '../services/fmClient';
-import { diffSchemaFields, diffSchemaSnapshots } from '../services/schemaDiff';
+import {
+  diffSchemaFieldsInWorker,
+  diffSchemaSnapshotsInWorker,
+  SchemaDiffCancelledError
+} from '../services/schemaDiff';
 import type { SchemaSnapshotStore } from '../services/schemaSnapshotStore';
 import type { SchemaService } from '../services/schemaService';
 import { extractFieldsFromMetadata } from '../services/schemaService';
 import type { Logger } from '../services/logger';
 import type { ProfileStore } from '../services/profileStore';
 import type { SettingsService } from '../services/settingsService';
-import type { SchemaSnapshot } from '../types/fm';
+import type { SchemaDiffResult, SchemaSnapshot } from '../types/fm';
 import {
   openJsonDocument,
   parseLayoutArg,
@@ -128,14 +132,36 @@ export function registerSchemaSnapshotCommands(
         return;
       }
 
-      const diff = diffSchemaSnapshots(
-        olderSnapshot,
-        newerSnapshot,
-        extractFieldsFromMetadata(olderSnapshot.metadata),
-        extractFieldsFromMetadata(newerSnapshot.metadata)
-      );
+      try {
+        const diff = await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Diffing schema snapshots',
+            cancellable: true
+          },
+          (_progress, token) =>
+            diffSchemaSnapshotsInWorker(
+              olderSnapshot,
+              newerSnapshot,
+              extractFieldsFromMetadata(olderSnapshot.metadata),
+              extractFieldsFromMetadata(newerSnapshot.metadata),
+              token
+            )
+        );
 
-      SchemaDiffPanel.createOrShow(context, diff);
+        SchemaDiffPanel.createOrShow(context, diff);
+      } catch (error) {
+        if (error instanceof SchemaDiffCancelledError) {
+          logger.info('Schema snapshot diff was cancelled.');
+          return;
+        }
+
+        await showCommandError(error, {
+          fallbackMessage: 'Failed to diff schema snapshots.',
+          logger,
+          logMessage: 'Failed to diff selected schema snapshots.'
+        });
+      }
     }),
 
     vscode.commands.registerCommand(
@@ -167,13 +193,24 @@ export function registerSchemaSnapshotCommands(
             return;
           }
 
-          const diff = diffSchemaFields({
-            profileId: profile.id,
-            layout,
-            olderSnapshotId: latest.id,
-            beforeFields: extractFieldsFromMetadata(latest.metadata),
-            afterFields: currentSchema.fields
-          });
+          const diff = await vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: 'Diffing schema against latest snapshot',
+              cancellable: true
+            },
+            (_progress, token) =>
+              diffSchemaFieldsInWorker(
+                {
+                  profileId: profile.id,
+                  layout,
+                  olderSnapshotId: latest.id,
+                  beforeFields: extractFieldsFromMetadata(latest.metadata),
+                  afterFields: currentSchema.fields
+                },
+                token
+              )
+          );
 
           SchemaDiffPanel.createOrShow(context, diff);
           publishDiffDiagnosticsIfEnabled(
@@ -184,6 +221,11 @@ export function registerSchemaSnapshotCommands(
             settingsService.isSchemaDiagnosticsEnabled()
           );
         } catch (error) {
+          if (error instanceof SchemaDiffCancelledError) {
+            logger.info('Schema diff against latest snapshot was cancelled.');
+            return;
+          }
+
           await showCommandError(error, {
             fallbackMessage: 'Failed to diff schema against latest snapshot.',
             logger,
@@ -266,7 +308,7 @@ function publishDiffDiagnosticsIfEnabled(
   diagnostics: vscode.DiagnosticCollection,
   profileId: string,
   layout: string,
-  diff: ReturnType<typeof diffSchemaFields>,
+  diff: SchemaDiffResult,
   enabled: boolean
 ): void {
   const uri = vscode.Uri.parse(

--- a/extension/src/services/schemaDiff.ts
+++ b/extension/src/services/schemaDiff.ts
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import { Worker } from 'node:worker_threads';
+
 import type {
   FieldDiffAttributeChange,
   FileMakerFieldMetadata,
@@ -13,6 +16,44 @@ export interface SchemaDiffInput {
   newerSnapshotId?: string;
   beforeFields: FileMakerFieldMetadata[];
   afterFields: FileMakerFieldMetadata[];
+}
+
+export interface SchemaDiffCancellationToken {
+  readonly isCancellationRequested: boolean;
+  readonly onCancellationRequested?: (listener: () => void) => { dispose(): void };
+}
+
+export type SchemaDiffWorkerRequest = SchemaDiffInput;
+
+export type SchemaDiffWorkerMessage =
+  | {
+      type: 'success';
+      diff: SchemaDiffResult;
+    }
+  | {
+      type: 'error';
+      message: string;
+      stack?: string;
+    };
+
+export interface SchemaDiffWorkerHandle {
+  postMessage(value: SchemaDiffWorkerRequest): void;
+  once(event: 'message', listener: (message: unknown) => void): this;
+  once(event: 'error', listener: (error: Error) => void): this;
+  once(event: 'exit', listener: (code: number) => void): this;
+  removeAllListeners(event?: 'message' | 'error' | 'exit'): this;
+  terminate(): Promise<number>;
+}
+
+export interface SchemaDiffWorkerOptions {
+  workerFactory?: () => SchemaDiffWorkerHandle;
+}
+
+export class SchemaDiffCancelledError extends Error {
+  public constructor() {
+    super('Schema diff was cancelled.');
+    this.name = 'SchemaDiffCancelledError';
+  }
 }
 
 export function diffSchemaFields(input: SchemaDiffInput): SchemaDiffResult {
@@ -81,6 +122,118 @@ export function diffSchemaSnapshots(
   });
 }
 
+export function diffSchemaFieldsInWorker(
+  input: SchemaDiffInput,
+  cancellationToken?: SchemaDiffCancellationToken,
+  options: SchemaDiffWorkerOptions = {}
+): Promise<SchemaDiffResult> {
+  if (cancellationToken?.isCancellationRequested) {
+    return Promise.reject(new SchemaDiffCancelledError());
+  }
+
+  return new Promise((resolve, reject) => {
+    const worker = (options.workerFactory ?? createSchemaDiffWorker)();
+    let settled = false;
+    let cancellationRegistration: { dispose(): void } | undefined;
+
+    const cleanup = (): void => {
+      cancellationRegistration?.dispose();
+      worker.removeAllListeners('message');
+      worker.removeAllListeners('error');
+      worker.removeAllListeners('exit');
+    };
+
+    const settle = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const terminateWorker = (): void => {
+      void worker.terminate().catch(() => undefined);
+    };
+
+    const settleWithCancellation = (): void => {
+      settle(() => {
+        terminateWorker();
+        reject(new SchemaDiffCancelledError());
+      });
+    };
+
+    cancellationRegistration = cancellationToken?.onCancellationRequested?.(() => {
+      settleWithCancellation();
+    });
+
+    worker.once('message', (message) => {
+      settle(() => {
+        if (isSchemaDiffWorkerSuccessMessage(message)) {
+          resolve(message.diff);
+          return;
+        }
+
+        if (isSchemaDiffWorkerErrorMessage(message)) {
+          reject(createWorkerError(message));
+          return;
+        }
+
+        reject(new Error('Schema diff worker returned an unexpected response.'));
+      });
+    });
+
+    worker.once('error', (error) => {
+      settle(() => {
+        reject(error);
+      });
+    });
+
+    worker.once('exit', (code) => {
+      settle(() => {
+        if (code === 0) {
+          reject(new Error('Schema diff worker exited before returning a result.'));
+          return;
+        }
+
+        reject(new Error(`Schema diff worker stopped with exit code ${code}.`));
+      });
+    });
+
+    try {
+      worker.postMessage(input);
+    } catch (error) {
+      settle(() => {
+        terminateWorker();
+        reject(error);
+      });
+    }
+  });
+}
+
+export function diffSchemaSnapshotsInWorker(
+  olderSnapshot: SchemaSnapshot,
+  newerSnapshot: SchemaSnapshot,
+  beforeFields: FileMakerFieldMetadata[],
+  afterFields: FileMakerFieldMetadata[],
+  cancellationToken?: SchemaDiffCancellationToken,
+  options: SchemaDiffWorkerOptions = {}
+): Promise<SchemaDiffResult> {
+  return diffSchemaFieldsInWorker(
+    {
+      profileId: newerSnapshot.profileId,
+      layout: newerSnapshot.layout,
+      olderSnapshotId: olderSnapshot.id,
+      newerSnapshotId: newerSnapshot.id,
+      beforeFields,
+      afterFields
+    },
+    cancellationToken,
+    options
+  );
+}
+
 function diffFieldAttributes(
   beforeField: FileMakerFieldMetadata,
   afterField: FileMakerFieldMetadata
@@ -141,4 +294,38 @@ function isEqual(left: unknown, right: unknown): boolean {
 
 function sortFieldsByName(fields: FileMakerFieldMetadata[]): FileMakerFieldMetadata[] {
   return [...fields].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function createSchemaDiffWorker(): SchemaDiffWorkerHandle {
+  return new Worker(path.join(__dirname, 'schemaDiffWorker.js'));
+}
+
+function isSchemaDiffWorkerSuccessMessage(
+  message: unknown
+): message is Extract<SchemaDiffWorkerMessage, { type: 'success' }> {
+  return isRecord(message) && message.type === 'success' && isRecord(message.diff);
+}
+
+function isSchemaDiffWorkerErrorMessage(
+  message: unknown
+): message is Extract<SchemaDiffWorkerMessage, { type: 'error' }> {
+  return (
+    isRecord(message) &&
+    message.type === 'error' &&
+    typeof message.message === 'string' &&
+    (message.stack === undefined || typeof message.stack === 'string')
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function createWorkerError(message: Extract<SchemaDiffWorkerMessage, { type: 'error' }>): Error {
+  const error = new Error(message.message);
+  if (message.stack) {
+    error.stack = message.stack;
+  }
+
+  return error;
 }

--- a/extension/src/services/schemaDiffWorker.ts
+++ b/extension/src/services/schemaDiffWorker.ts
@@ -1,0 +1,32 @@
+import { parentPort } from 'node:worker_threads';
+
+import {
+  diffSchemaFields,
+  type SchemaDiffWorkerMessage,
+  type SchemaDiffWorkerRequest
+} from './schemaDiff';
+
+const port = parentPort;
+
+if (!port) {
+  throw new Error('Schema diff worker must run inside a worker thread.');
+}
+
+port.once('message', (request: SchemaDiffWorkerRequest) => {
+  try {
+    const diff = diffSchemaFields(request);
+    postMessage({ type: 'success', diff });
+  } catch (error) {
+    postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined
+    });
+  } finally {
+    port.close();
+  }
+});
+
+function postMessage(message: SchemaDiffWorkerMessage): void {
+  port?.postMessage(message);
+}

--- a/extension/test/unit/schemaDiff.test.ts
+++ b/extension/test/unit/schemaDiff.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
 
-import { diffSchemaFields } from '../../src/services/schemaDiff';
+import {
+  diffSchemaFields,
+  diffSchemaFieldsInWorker,
+  SchemaDiffCancelledError,
+  type SchemaDiffCancellationToken,
+  type SchemaDiffWorkerHandle,
+  type SchemaDiffWorkerRequest
+} from '../../src/services/schemaDiff';
 
 describe('schemaDiff', () => {
   it('detects added, removed, and changed fields', () => {
@@ -37,4 +45,88 @@ describe('schemaDiff', () => {
     expect(diff.hasChanges).toBe(false);
     expect(diff.summary).toEqual({ added: 0, removed: 0, changed: 0 });
   });
+
+  it('posts schema diff input to a worker and resolves the worker result', async () => {
+    const worker = new FakeSchemaDiffWorker();
+    const input: SchemaDiffWorkerRequest = {
+      profileId: 'profile-a',
+      layout: 'Contacts',
+      beforeFields: [{ name: 'FirstName', type: 'text' }],
+      afterFields: [{ name: 'FirstName', type: 'text' }]
+    };
+    const diff = diffSchemaFields(input);
+
+    const result = diffSchemaFieldsInWorker(input, undefined, {
+      workerFactory: () => worker
+    });
+
+    expect(worker.messages).toEqual([input]);
+
+    worker.emit('message', {
+      type: 'success',
+      diff
+    });
+
+    await expect(result).resolves.toEqual(diff);
+  });
+
+  it('terminates the worker when schema diff cancellation is requested', async () => {
+    const worker = new FakeSchemaDiffWorker();
+    const cancellation = createCancellationToken();
+    const input: SchemaDiffWorkerRequest = {
+      profileId: 'profile-a',
+      layout: 'Contacts',
+      beforeFields: [{ name: 'FirstName', type: 'text' }],
+      afterFields: [{ name: 'FirstName', type: 'number' }]
+    };
+
+    const result = diffSchemaFieldsInWorker(input, cancellation.token, {
+      workerFactory: () => worker
+    });
+
+    cancellation.cancel();
+
+    await expect(result).rejects.toBeInstanceOf(SchemaDiffCancelledError);
+    expect(worker.terminated).toBe(true);
+  });
 });
+
+class FakeSchemaDiffWorker extends EventEmitter implements SchemaDiffWorkerHandle {
+  public readonly messages: SchemaDiffWorkerRequest[] = [];
+  public terminated = false;
+
+  public postMessage(value: SchemaDiffWorkerRequest): void {
+    this.messages.push(value);
+  }
+
+  public terminate(): Promise<number> {
+    this.terminated = true;
+    return Promise.resolve(1);
+  }
+}
+
+function createCancellationToken(): {
+  token: SchemaDiffCancellationToken;
+  cancel: () => void;
+} {
+  let listener: (() => void) | undefined;
+  const token = {
+    isCancellationRequested: false,
+    onCancellationRequested: (callback: () => void) => {
+      listener = callback;
+      return {
+        dispose: () => {
+          listener = undefined;
+        }
+      };
+    }
+  };
+
+  return {
+    token,
+    cancel: () => {
+      token.isCancellationRequested = true;
+      listener?.();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- run schema snapshot diffs through a dedicated Node worker thread
- add VS Code progress cancellation that terminates the worker
- bundle the worker artifact and cover worker/cancellation behavior in schema diff tests

Closes #174

## Validation
- ai-pipeline validate --id 174: no validation.local commands declared
- git diff --check: passed
- npm run lint -w extension: passed
- npm run typecheck -w extension: passed
- npm test -w extension -- --run test/unit/schemaDiff.test.ts: 4 passed
- npm run build -w shared && npm run build -w extension: passed
- npm test -w extension: 448 passed
- node worker smoke against extension/dist/schemaDiffWorker.js: success, changed=1