### PR TITLE
Network request log viewer for FM API calls (#177)

### DIFF
--- a/artifacts/local-review/issue-177-validation.md
+++ b/artifacts/local-review/issue-177-validation.md
@@ -1,0 +1,8 @@
+# Issue 177 Local Validation
+
+- `ai-pipeline validate --id 177`: passed; no `validation.local` commands declared.
+- `npm run lint -w extension`: passed.
+- `npm run typecheck`: passed across `shared`, `designer-ui`, `runtime-next`, and `extension`.
+- `npm test`: passed across `designer-ui` (6 files, 15 tests), `runtime-next` (3 files, 9 tests), and `extension` (79 files, 450 tests).
+- `npm run build -w shared`: passed; prerequisite for designer UI build resolution.
+- `npm run build -w extension`: passed.

--- a/extension/package.json
+++ b/extension/package.json
@@ -152,6 +152,10 @@
         "title": "FileMaker: Show Diagnostics"
       },
       {
+        "command": "filemakerDataApiTools.openNetworkLog",
+        "title": "FileMaker: Open Network Log"
+      },
+      {
         "command": "filemakerDataApiTools.addConnectionProfile",
         "title": "FileMaker: Add Connection Profile"
       },
@@ -598,6 +602,7 @@
         { "command": "filemakerDataApiTools.showJobs", "when": "filemaker.powerUserMode" },
         { "command": "filemakerDataApiTools.showRequestHistory", "when": "filemaker.powerUserMode" },
         { "command": "filemakerDataApiTools.openDiagnosticsDashboard", "when": "filemaker.powerUserMode" },
+        { "command": "filemakerDataApiTools.openNetworkLog" },
         { "command": "filemakerDataApiTools.showCircuitBreakerStatus", "when": "filemaker.powerUserMode" },
         { "command": "filemakerDataApiTools.reloadPlugins", "when": "filemaker.powerUserMode" },
         { "command": "filemakerDataApiTools.listActivePlugins", "when": "filemaker.powerUserMode" },
@@ -712,6 +717,11 @@
           "type": "boolean",
           "default": false,
           "description": "Publish schema diff changes to the Problems panel when diffing against latest snapshot."
+        },
+        "filemaker.diagnostics.captureNetwork": {
+          "type": "boolean",
+          "default": false,
+          "description": "Capture recent FileMaker Data API HTTP requests in the in-memory network log. Authorization headers and secret-like values are redacted."
         },
         "filemaker.typegen.outputDir": {
           "type": "string",

--- a/extension/src/commands/diagnostics.ts
+++ b/extension/src/commands/diagnostics.ts
@@ -1,20 +1,28 @@
 import * as vscode from 'vscode';
 
 import { DiagnosticsDashboardPanel } from '../diagnostics/diagnosticsDashboard';
+import { NetworkLogPanel } from '../diagnostics/networkLogPanel';
 import type { MetricsStore } from '../diagnostics/metricsStore';
+import type { NetworkLogStore } from '../diagnostics/networkLogStore';
 import type { HistoryStore } from '../services/historyStore';
 
 interface RegisterDiagnosticsCommandDeps {
   metricsStore: MetricsStore;
   historyStore: HistoryStore;
+  networkLogStore: NetworkLogStore;
 }
 
-export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandDeps): vscode.Disposable[] {
-  const { metricsStore, historyStore } = deps;
+export function registerDiagnosticsCommands(
+  deps: RegisterDiagnosticsCommandDeps
+): vscode.Disposable[] {
+  const { metricsStore, historyStore, networkLogStore } = deps;
 
   return [
     vscode.commands.registerCommand('filemakerDataApiTools.openDiagnosticsDashboard', () => {
       DiagnosticsDashboardPanel.createOrShow(metricsStore, historyStore);
+    }),
+    vscode.commands.registerCommand('filemakerDataApiTools.openNetworkLog', () => {
+      NetworkLogPanel.createOrShow(networkLogStore);
     })
   ];
 }

--- a/extension/src/diagnostics/networkLogPanel.ts
+++ b/extension/src/diagnostics/networkLogPanel.ts
@@ -1,0 +1,211 @@
+import * as vscode from 'vscode';
+
+import { buildWebviewCsp, createNonce } from '../webviews/common/csp';
+import { hasMessageType } from '../webviews/common/messageValidation';
+import type { NetworkLogStore } from './networkLogStore';
+
+export class NetworkLogPanel {
+  private static current: NetworkLogPanel | undefined;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  private constructor(
+    private readonly panel: vscode.WebviewPanel,
+    private readonly networkLogStore: NetworkLogStore
+  ) {
+    this.disposables.push(
+      this.panel.onDidDispose(() => {
+        NetworkLogPanel.current = undefined;
+        this.dispose();
+      }),
+      this.networkLogStore.onDidChange(() => {
+        void this.render();
+      }),
+      this.panel.webview.onDidReceiveMessage((message: unknown) => {
+        if (hasMessageType(message, 'refresh')) {
+          void this.render();
+          return;
+        }
+
+        if (hasMessageType(message, 'clear')) {
+          void this.clear();
+        }
+      })
+    );
+
+    void this.render();
+  }
+
+  public static createOrShow(networkLogStore: NetworkLogStore): void {
+    const column = vscode.ViewColumn.One;
+
+    if (NetworkLogPanel.current) {
+      NetworkLogPanel.current.panel.reveal(column);
+      void NetworkLogPanel.current.render();
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      'filemakerNetworkLog',
+      'FileMaker Network Log',
+      column,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true
+      }
+    );
+
+    NetworkLogPanel.current = new NetworkLogPanel(panel, networkLogStore);
+  }
+
+  private async clear(): Promise<void> {
+    await this.networkLogStore.clear();
+    await this.render();
+  }
+
+  private async render(): Promise<void> {
+    const entries = this.networkLogStore.listEntries();
+    const nonce = createNonce();
+    const csp = buildWebviewCsp(this.panel.webview, {
+      nonce,
+      allowInlineStyleWithNonce: true
+    });
+    const payload = JSON.stringify({ entries }).replace(/</g, '\\u003c');
+
+    this.panel.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />
+  <title>FileMaker Network Log</title>
+  <style nonce="${nonce}">
+    body { font-family: 'Segoe UI', sans-serif; margin: 0; color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+    .wrap { padding: 14px; display: grid; gap: 12px; }
+    .toolbar { display: flex; align-items: center; gap: 8px; }
+    button { border: 1px solid var(--vscode-button-border, transparent); border-radius: 4px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); padding: 6px 10px; cursor: pointer; }
+    button:hover { background: var(--vscode-button-hoverBackground); }
+    .count { color: var(--vscode-descriptionForeground); font-size: 12px; margin-left: auto; }
+    table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+    th, td { border: 1px solid var(--vscode-panel-border); text-align: left; padding: 6px 8px; font-size: 12px; vertical-align: top; }
+    th { background: var(--vscode-editorGroupHeader-tabsBackground); font-weight: 600; }
+    tbody tr.request-row { cursor: pointer; }
+    tbody tr.request-row:hover { background: var(--vscode-list-hoverBackground); }
+    .time { width: 178px; }
+    .method { width: 70px; }
+    .status { width: 74px; }
+    .duration { width: 92px; }
+    .url { overflow-wrap: anywhere; }
+    .ok { color: var(--vscode-testing-iconPassed); }
+    .fail { color: var(--vscode-testing-iconFailed); }
+    .details { display: none; background: var(--vscode-sideBar-background); }
+    .details.open { display: table-row; }
+    .detail-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 10px; padding: 8px 0; }
+    .detail-block { min-width: 0; display: grid; gap: 4px; }
+    .detail-title { font-weight: 600; color: var(--vscode-descriptionForeground); }
+    pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; background: var(--vscode-textCodeBlock-background); padding: 8px; border-radius: 4px; max-height: 260px; overflow: auto; }
+    .empty { color: var(--vscode-descriptionForeground); }
+    @media (max-width: 720px) {
+      .time { width: 130px; }
+      .method, .status, .duration { width: 58px; }
+      .detail-grid { grid-template-columns: minmax(0, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="toolbar">
+      <button id="refreshBtn">Refresh</button>
+      <button id="clearBtn">Clear</button>
+      <span id="count" class="count"></span>
+    </div>
+    <table>
+      <thead>
+        <tr><th class="time">Timestamp</th><th class="method">Method</th><th class="url">URL</th><th class="status">Status</th><th class="duration">Duration</th></tr>
+      </thead>
+      <tbody id="entriesBody"></tbody>
+    </table>
+  </div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const payload = ${payload};
+    const entries = payload.entries || [];
+    const entriesBody = document.getElementById('entriesBody');
+    const count = document.getElementById('count');
+
+    count.textContent = entries.length + ' / 100 requests';
+    entriesBody.innerHTML = entries.length
+      ? entries.map((entry) => renderRow(entry)).join('')
+      : '<tr><td colspan="5" class="empty">No network requests captured.</td></tr>';
+
+    for (const row of document.querySelectorAll('.request-row')) {
+      row.addEventListener('click', () => {
+        const target = document.getElementById('details-' + row.dataset.id);
+        if (target) {
+          target.classList.toggle('open');
+        }
+      });
+    }
+
+    document.getElementById('refreshBtn').addEventListener('click', () => {
+      vscode.postMessage({ type: 'refresh' });
+    });
+
+    document.getElementById('clearBtn').addEventListener('click', () => {
+      vscode.postMessage({ type: 'clear' });
+    });
+
+    function renderRow(entry) {
+      const statusClass = entry.responseStatus && entry.responseStatus >= 400 ? 'fail' : 'ok';
+      const status = entry.responseStatus ?? (entry.errorMessage ? 'Error' : '-');
+      return '<tr class="request-row" data-id="' + escapeHtml(entry.id) + '">' +
+        '<td>' + escapeHtml(formatTime(entry.timestamp)) + '</td>' +
+        '<td>' + escapeHtml(entry.method) + '</td>' +
+        '<td class="url">' + escapeHtml(entry.relativeUrl) + '</td>' +
+        '<td class="' + statusClass + '">' + escapeHtml(status) + '</td>' +
+        '<td>' + escapeHtml(entry.durationMs) + 'ms</td>' +
+      '</tr>' +
+      '<tr id="details-' + escapeHtml(entry.id) + '" class="details"><td colspan="5">' +
+        '<div class="detail-grid">' +
+          renderBlock('Full URL', entry.url) +
+          renderBlock('Request Headers', entry.requestHeaders) +
+          renderBlock('Request Body', entry.requestBody) +
+          renderBlock('Response Headers', entry.responseHeaders) +
+          renderBlock('Response Body', entry.responseBody) +
+          renderBlock('Error', entry.errorMessage || '') +
+        '</div>' +
+      '</td></tr>';
+    }
+
+    function renderBlock(title, value) {
+      const text = typeof value === 'string' ? value : JSON.stringify(value ?? null, null, 2);
+      return '<div class="detail-block">' +
+        '<div class="detail-title">' + escapeHtml(title) + '</div>' +
+        '<pre>' + escapeHtml(text) + '</pre>' +
+      '</div>';
+    }
+
+    function formatTime(value) {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+  </script>
+</body>
+</html>`;
+  }
+
+  private dispose(): void {
+    while (this.disposables.length > 0) {
+      this.disposables.pop()?.dispose();
+    }
+  }
+}

--- a/extension/src/diagnostics/networkLogStore.ts
+++ b/extension/src/diagnostics/networkLogStore.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'crypto';
+
+import type * as vscode from 'vscode';
+
+import type { NetworkLogRecordInput, NetworkLogRecorder } from '../types/fm';
+import { redactHeaders, redactString, redactValue } from '../utils/redact';
+
+export interface NetworkLogEntry {
+  id: string;
+  requestId: string;
+  timestamp: string;
+  method: string;
+  url: string;
+  relativeUrl: string;
+  requestHeaders: Record<string, string>;
+  requestBody?: unknown;
+  responseStatus?: number;
+  responseHeaders: Record<string, string>;
+  responseBody?: unknown;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+interface NetworkLogStoreOptions {
+  getMaxEntries?: () => number;
+  now?: () => Date;
+  createEventEmitter?: () => vscode.EventEmitter<void>;
+}
+
+export class NetworkLogStore implements NetworkLogRecorder, vscode.Disposable {
+  private readonly getMaxEntries: () => number;
+  private readonly now: () => Date;
+  private readonly onDidChangeEmitter?: vscode.EventEmitter<void>;
+  private entries: NetworkLogEntry[] = [];
+
+  public readonly onDidChange: vscode.Event<void>;
+
+  public constructor(options?: NetworkLogStoreOptions) {
+    this.getMaxEntries = options?.getMaxEntries ?? (() => 100);
+    this.now = options?.now ?? (() => new Date());
+    this.onDidChangeEmitter = options?.createEventEmitter?.();
+    this.onDidChange = this.onDidChangeEmitter?.event ?? (() => ({ dispose: () => undefined }));
+  }
+
+  public listEntries(): NetworkLogEntry[] {
+    return [...this.entries];
+  }
+
+  public async clear(): Promise<void> {
+    this.entries = [];
+    this.onDidChangeEmitter?.fire();
+  }
+
+  public async record(input: NetworkLogRecordInput): Promise<void> {
+    const requestId = input.requestId || randomUUID();
+    const entry: NetworkLogEntry = {
+      id: randomUUID(),
+      requestId,
+      timestamp: this.now().toISOString(),
+      method: input.method.toUpperCase(),
+      url: redactString(input.url),
+      relativeUrl: redactString(input.relativeUrl),
+      requestHeaders: redactHeaders(input.requestHeaders) ?? {},
+      requestBody: redactValue(input.requestBody),
+      responseStatus: input.responseStatus,
+      responseHeaders: redactHeaders(input.responseHeaders) ?? {},
+      responseBody: redactValue(input.responseBody),
+      durationMs: Math.max(0, Math.round(input.durationMs)),
+      errorMessage: input.errorMessage ? redactString(input.errorMessage) : undefined
+    };
+
+    this.entries = [entry, ...this.entries].slice(0, normalizeMaxEntries(this.getMaxEntries()));
+    this.onDidChangeEmitter?.fire();
+  }
+
+  public dispose(): void {
+    this.onDidChangeEmitter?.dispose();
+  }
+}
+
+function normalizeMaxEntries(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    return 100;
+  }
+
+  return Math.min(value, 100);
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -36,6 +36,7 @@ import { EnvironmentSetStore } from './enterprise/environmentSetStore';
 import { EnvironmentCompareService } from './enterprise/environmentCompareService';
 import { RoleGuard } from './enterprise/roleGuard';
 import { MetricsStore } from './diagnostics/metricsStore';
+import { NetworkLogStore } from './diagnostics/networkLogStore';
 import { OfflineModeService } from './offline/offlineModeService';
 import { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
 import { PluginRegistry } from './plugins/pluginRegistry';
@@ -107,6 +108,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const metricsStore = new MetricsStore(context.workspaceState, {
     getMaxEntries: () => 200
   });
+  const networkLogStore = new NetworkLogStore({
+    getMaxEntries: () => 100,
+    createEventEmitter: () => new vscode.EventEmitter<void>()
+  });
   const jobRunner = new JobRunner(context.workspaceState);
 
   const timeoutMs = settingsService.getRequestTimeoutMs();
@@ -122,7 +127,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     () => ({
       maxAgeMs: settingsService.getSessionMaxAgeMs(),
       refreshLeadMs: settingsService.getSessionRefreshLeadMs()
-    })
+    }),
+    {
+      recorder: networkLogStore,
+      isEnabled: () => settingsService.isNetworkCaptureEnabled()
+    }
   );
   const schemaService = new SchemaService(fmClient, logger, {
     getCacheTtlMs: () =>
@@ -302,7 +311,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   });
   const diagnosticsDisposables = registerDiagnosticsCommands({
     metricsStore,
-    historyStore
+    historyStore,
+    networkLogStore
   });
   const offlineDisposables = registerOfflineCommands({
     profileStore,
@@ -372,6 +382,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ...pluginDisposables,
     ...circuitBreakerDisposables,
     ...fmWebProjectDisposables,
+    networkLogStore,
     diagnostics,
     jobsStatusBar,
     jobsSubscription,

--- a/extension/src/services/fmClient.ts
+++ b/extension/src/services/fmClient.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'crypto';
 
-import axios, { type AxiosError, type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import axios, {
+  type AxiosError,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type AxiosResponse
+} from 'axios';
 
 import type {
   ConnectionProfile,
@@ -8,6 +13,7 @@ import type {
   FileMakerRecord,
   FindRecordsRequest,
   FindRecordsResult,
+  NetworkLogRecorder,
   RequestHistoryRecorder,
   RequestMetricsRecorder,
   RunScriptRequest,
@@ -78,6 +84,11 @@ export interface FMClientSessionOptions {
   now?: () => number;
 }
 
+export interface FMClientNetworkLogOptions {
+  recorder?: NetworkLogRecorder;
+  isEnabled?: () => boolean;
+}
+
 export class FMClient {
   private readonly httpClient: AxiosInstance;
   private readonly proxyClient: ProxyClient;
@@ -91,6 +102,8 @@ export class FMClient {
   private readonly getSessionMaxAgeMs: () => number;
   private readonly getSessionRefreshLeadMs: () => number;
   private readonly now: () => number;
+  private readonly networkLogRecorder?: NetworkLogRecorder;
+  private readonly isNetworkCaptureEnabled: () => boolean;
 
   public constructor(
     private readonly secretStore: SecretStore,
@@ -100,7 +113,8 @@ export class FMClient {
     proxyClient?: ProxyClient,
     private readonly historyRecorder?: RequestHistoryRecorder,
     private readonly metricsRecorder?: RequestMetricsRecorder,
-    sessionOptions?: FMClientSessionOptions | (() => FMClientSessionOptions)
+    sessionOptions?: FMClientSessionOptions | (() => FMClientSessionOptions),
+    networkLogOptions?: FMClientNetworkLogOptions
   ) {
     this.logger = logger;
     this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -119,6 +133,8 @@ export class FMClient {
     this.getSessionRefreshLeadMs = () =>
       resolveOptions().refreshLeadMs ?? DEFAULT_SESSION_REFRESH_LEAD_MS;
     this.now = () => resolveOptions().now?.() ?? Date.now();
+    this.networkLogRecorder = networkLogOptions?.recorder;
+    this.isNetworkCaptureEnabled = networkLogOptions?.isEnabled ?? (() => false);
     this.sessionTracker = new SessionTokenTracker({
       defaultMaxAgeMs: DEFAULT_SESSION_MAX_AGE_MS,
       defaultRefreshLeadMs: DEFAULT_SESSION_REFRESH_LEAD_MS
@@ -175,15 +191,19 @@ export class FMClient {
         const basic = Buffer.from(`${username}:${password}`, 'utf8').toString('base64');
 
         try {
-          const envelope = await this.requestNoAuth<DataApiSessionResponse>(profile, {
-            method: 'POST',
-            path: '/sessions',
-            headers: {
-              Authorization: `Basic ${basic}`
+          const envelope = await this.requestNoAuth<DataApiSessionResponse>(
+            profile,
+            {
+              method: 'POST',
+              path: '/sessions',
+              headers: {
+                Authorization: `Basic ${basic}`
+              },
+              data: {},
+              signal: control?.signal
             },
-            data: {},
-            signal: control?.signal
-          });
+            trace
+          );
           trace.endpoint = 'POST /sessions';
 
           const token = envelope.response.token;
@@ -856,7 +876,11 @@ export class FMClient {
         timeout: this.timeoutMs
       };
 
-      const response = await this.httpClient.request<DataApiEnvelope<TResponse>>(config);
+      const response = await this.sendDataApiRequest<DataApiEnvelope<TResponse>>(
+        request,
+        config,
+        trace
+      );
       return response.data;
     } catch (error) {
       const axiosError = error as AxiosError;
@@ -918,7 +942,11 @@ export class FMClient {
         validateStatus: (status) => (status >= 200 && status < 300) || status === 304
       };
 
-      const response = await this.httpClient.request<DataApiEnvelope<TResponse>>(config);
+      const response = await this.sendDataApiRequest<DataApiEnvelope<TResponse>>(
+        request,
+        config,
+        trace
+      );
       const headers = normalizeHeaders(response.headers as Record<string, unknown>);
       if (response.status === 304) {
         return {
@@ -961,7 +989,8 @@ export class FMClient {
 
   private async requestNoAuth<TResponse extends Record<string, unknown>>(
     profile: ConnectionProfile,
-    request: RequestOptions
+    request: RequestOptions,
+    trace?: RequestTrace
   ): Promise<DataApiEnvelope<TResponse>> {
     const config: AxiosRequestConfig = {
       method: request.method,
@@ -977,8 +1006,77 @@ export class FMClient {
       timeout: this.timeoutMs
     };
 
-    const response = await this.httpClient.request<DataApiEnvelope<TResponse>>(config);
+    const response = await this.sendDataApiRequest<DataApiEnvelope<TResponse>>(
+      request,
+      config,
+      trace
+    );
     return response.data;
+  }
+
+  private async sendDataApiRequest<T>(
+    request: RequestOptions,
+    config: AxiosRequestConfig,
+    trace?: RequestTrace
+  ): Promise<AxiosResponse<T>> {
+    const start = Date.now();
+
+    try {
+      const response = await this.httpClient.request<T>(config);
+      await this.recordNetworkLog(request, config, start, response, undefined, trace);
+      return response;
+    } catch (error) {
+      await this.recordNetworkLog(request, config, start, undefined, error, trace);
+      throw error;
+    }
+  }
+
+  private async recordNetworkLog<T>(
+    request: RequestOptions,
+    config: AxiosRequestConfig,
+    start: number,
+    response?: AxiosResponse<T>,
+    error?: unknown,
+    trace?: RequestTrace
+  ): Promise<void> {
+    if (!this.networkLogRecorder) {
+      return;
+    }
+
+    let enabled: boolean;
+    try {
+      enabled = this.isNetworkCaptureEnabled();
+    } catch (settingsError) {
+      this.logger.warn('Failed to read network capture setting.', { error: settingsError });
+      return;
+    }
+
+    if (!enabled) {
+      return;
+    }
+
+    const axiosError = error as AxiosError;
+    const errorResponse = axiosError?.isAxiosError ? axiosError.response : undefined;
+    const responseForLog = response ?? errorResponse;
+    const url = appendQueryParams(String(config.url ?? ''), config.params);
+
+    try {
+      await this.networkLogRecorder.record({
+        requestId: trace?.requestId,
+        method: request.method,
+        url,
+        relativeUrl: toRelativeUrl(url),
+        requestHeaders: headersToRecord(config.headers),
+        requestBody: config.data,
+        responseStatus: responseForLog?.status,
+        responseHeaders: headersToRecord(responseForLog?.headers),
+        responseBody: responseForLog?.data,
+        durationMs: Date.now() - start,
+        errorMessage: error ? getErrorMessage(error) : undefined
+      });
+    } catch (recordError) {
+      this.logger.warn('Failed to record network request log entry.', { error: recordError });
+    }
   }
 
   private buildProfileCacheKey(profile: ConnectionProfile): string {
@@ -1192,4 +1290,60 @@ function normalizeHeaders(headers: Record<string, unknown>): Record<string, stri
   }
 
   return normalized;
+}
+
+function headersToRecord(headers: unknown): Record<string, unknown> | undefined {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return undefined;
+  }
+
+  const maybeSerializable = headers as { toJSON?: () => unknown };
+  if (typeof maybeSerializable.toJSON === 'function') {
+    const serialized = maybeSerializable.toJSON();
+    if (serialized && typeof serialized === 'object' && !Array.isArray(serialized)) {
+      return serialized as Record<string, unknown>;
+    }
+  }
+
+  return headers as Record<string, unknown>;
+}
+
+function appendQueryParams(url: string, params: unknown): string {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) {
+    return url;
+  }
+
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item !== undefined && item !== null) {
+          search.append(key, String(item));
+        }
+      }
+      continue;
+    }
+
+    search.append(key, String(value));
+  }
+
+  const query = search.toString();
+  if (!query) {
+    return url;
+  }
+
+  return `${url}${url.includes('?') ? '&' : '?'}${query}`;
+}
+
+function toRelativeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
 }

--- a/extension/src/services/settingsService.ts
+++ b/extension/src/services/settingsService.ts
@@ -205,6 +205,10 @@ export class SettingsService {
     return this.getConfiguration('filemaker').get<boolean>('schema.diagnostics.enabled', false);
   }
 
+  public isNetworkCaptureEnabled(): boolean {
+    return this.getConfiguration('filemaker').get<boolean>('diagnostics.captureNetwork', false);
+  }
+
   public getTypegenOutputDir(): string {
     const configured = this.getConfiguration('filemaker').get<string>('typegen.outputDir', 'filemaker-types');
     return sanitizeRelativeDir(configured, 'filemaker-types');

--- a/extension/src/types/fm.ts
+++ b/extension/src/types/fm.ts
@@ -260,6 +260,24 @@ export interface RequestMetricsRecorder {
   record(entry: RequestMetricsRecordInput): Promise<void>;
 }
 
+export interface NetworkLogRecordInput {
+  requestId?: string;
+  method: string;
+  url: string;
+  relativeUrl: string;
+  requestHeaders?: Record<string, unknown>;
+  requestBody?: unknown;
+  responseStatus?: number;
+  responseHeaders?: Record<string, unknown>;
+  responseBody?: unknown;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+export interface NetworkLogRecorder {
+  record(entry: NetworkLogRecordInput): Promise<void>;
+}
+
 export interface JobLogEntry {
   timestamp: string;
   level: 'info' | 'warn' | 'error';

--- a/extension/src/utils/redact.ts
+++ b/extension/src/utils/redact.ts
@@ -1,4 +1,4 @@
-const SECRET_KEY_PATTERN = /(authorization|password|token|secret|api[-_]?key|session)/i;
+const SECRET_KEY_PATTERN = /(authorization|password|token|secret|api[-_]?key|session|cookie)/i;
 
 const BEARER_OR_BASIC_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*/gi;
 

--- a/extension/test/unit/fmClient.test.ts
+++ b/extension/test/unit/fmClient.test.ts
@@ -1,6 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
+import { NetworkLogStore } from '../../src/diagnostics/networkLogStore';
 import { FMClient } from '../../src/services/fmClient';
 import { SecretStore } from '../../src/services/secretStore';
 import type { ConnectionProfile } from '../../src/types/fm';
@@ -66,6 +67,136 @@ describe('FMClient (unit)', () => {
     expect(headers['Content-Type']).toBe('application/json');
   });
 
+  it('captures redacted direct Data API network requests when enabled', async () => {
+    const axios = new FakeAxios();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+    const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+    const profile = createProfile();
+    const networkLogStore = new NetworkLogStore({
+      now: () => new Date('2026-05-24T12:00:00.000Z')
+    });
+
+    await secretStore.setPassword(profile.id, 'pass');
+
+    axios.request
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {
+          'x-session-id': 'server-session-header'
+        },
+        data: {
+          response: {
+            token: 'token-a'
+          },
+          messages: [{ code: '0', message: 'OK' }]
+        }
+      } as AxiosResponse<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {
+          'x-request-id': 'req-server-1'
+        },
+        data: {
+          response: {
+            layouts: [{ name: 'Contacts' }]
+          },
+          messages: [{ code: '0', message: 'OK' }]
+        }
+      } as AxiosResponse<Record<string, unknown>>);
+
+    const client = new FMClient(
+      secretStore,
+      logger,
+      15_000,
+      axios as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        recorder: networkLogStore,
+        isEnabled: () => true
+      }
+    );
+
+    await client.listLayouts(profile);
+
+    const entries = networkLogStore.listEntries();
+    expect(entries).toHaveLength(2);
+
+    const listEntry = entries.find((entry) => entry.relativeUrl.endsWith('/layouts'));
+    expect(listEntry?.method).toBe('GET');
+    expect(listEntry?.responseStatus).toBe(200);
+    expect(listEntry?.requestHeaders.Authorization).toBe('***');
+    expect(listEntry?.responseHeaders['x-request-id']).toBe('req-server-1');
+
+    const sessionEntry = entries.find((entry) => entry.relativeUrl.endsWith('/sessions'));
+    expect(sessionEntry?.method).toBe('POST');
+    expect(sessionEntry?.requestHeaders.Authorization).toBe('***');
+    expect(sessionEntry?.responseBody).toMatchObject({
+      response: {
+        token: '***'
+      }
+    });
+  });
+
+  it('does not capture direct Data API network requests when disabled', async () => {
+    const axios = new FakeAxios();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    };
+    const secretStore = new SecretStore(new InMemorySecretStorage() as never);
+    const profile = createProfile();
+    const networkLogStore = new NetworkLogStore();
+
+    await secretStore.setPassword(profile.id, 'pass');
+
+    axios.request
+      .mockResolvedValueOnce({
+        data: {
+          response: {
+            token: 'token-a'
+          },
+          messages: [{ code: '0', message: 'OK' }]
+        }
+      } as AxiosResponse<Record<string, unknown>>)
+      .mockResolvedValueOnce({
+        data: {
+          response: {
+            layouts: [{ name: 'Contacts' }]
+          },
+          messages: [{ code: '0', message: 'OK' }]
+        }
+      } as AxiosResponse<Record<string, unknown>>);
+
+    const client = new FMClient(
+      secretStore,
+      logger,
+      15_000,
+      axios as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        recorder: networkLogStore,
+        isEnabled: () => false
+      }
+    );
+
+    await client.listLayouts(profile);
+
+    expect(networkLogStore.listEntries()).toHaveLength(0);
+  });
+
   it('maps FileMaker error payloads to helpful errors', async () => {
     const axios = new FakeAxios();
     const logger = {
@@ -101,7 +232,9 @@ describe('FMClient (unit)', () => {
 
     const client = new FMClient(secretStore, logger, 15_000, axios as never);
 
-    await expect(client.listLayouts(profile)).rejects.toThrow('FileMaker API error (HTTP 500) [500]');
+    await expect(client.listLayouts(profile)).rejects.toThrow(
+      'FileMaker API error (HTTP 500) [500]'
+    );
   });
 
   it('re-authenticates once on 401 and retries request', async () => {

--- a/extension/test/unit/networkLogStore.test.ts
+++ b/extension/test/unit/networkLogStore.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { NetworkLogStore } from '../../src/diagnostics/networkLogStore';
+
+describe('NetworkLogStore', () => {
+  it('redacts authorization headers and secret-like payload values', async () => {
+    const store = new NetworkLogStore({
+      now: () => new Date('2026-05-24T12:00:00.000Z')
+    });
+
+    await store.record({
+      requestId: 'req-1',
+      method: 'POST',
+      url: 'https://fm.example.com/fmi/data/vLatest/databases/DB/sessions',
+      relativeUrl: '/fmi/data/vLatest/databases/DB/sessions',
+      requestHeaders: {
+        Authorization: 'Basic username-password',
+        Accept: 'application/json'
+      },
+      requestBody: {
+        password: 'secret',
+        fieldData: {
+          Name: 'Ada'
+        }
+      },
+      responseStatus: 200,
+      responseHeaders: {
+        'set-cookie': 'session=secret'
+      },
+      responseBody: {
+        response: {
+          token: 'session-token',
+          ok: true
+        }
+      },
+      durationMs: 12
+    });
+
+    const entry = store.listEntries()[0];
+    expect(entry?.timestamp).toBe('2026-05-24T12:00:00.000Z');
+    expect(entry?.requestHeaders.Authorization).toBe('***');
+    expect(entry?.requestHeaders.Accept).toBe('application/json');
+    expect(entry?.requestBody).toMatchObject({
+      password: '***',
+      fieldData: {
+        Name: 'Ada'
+      }
+    });
+    expect(entry?.responseHeaders['set-cookie']).toBe('***');
+    expect(entry?.responseBody).toMatchObject({
+      response: {
+        token: '***',
+        ok: true
+      }
+    });
+  });
+
+  it('keeps a bounded newest-first ring buffer of 100 entries', async () => {
+    const store = new NetworkLogStore({
+      getMaxEntries: () => 250
+    });
+
+    for (let index = 0; index < 105; index += 1) {
+      await store.record({
+        requestId: `req-${index}`,
+        method: 'GET',
+        url: `https://fm.example.com/request/${index}`,
+        relativeUrl: `/request/${index}`,
+        durationMs: index
+      });
+    }
+
+    const entries = store.listEntries();
+    expect(entries).toHaveLength(100);
+    expect(entries[0]?.requestId).toBe('req-104');
+    expect(entries[99]?.requestId).toBe('req-5');
+  });
+});

--- a/extension/test/unit/redact.test.ts
+++ b/extension/test/unit/redact.test.ts
@@ -28,10 +28,12 @@ describe('redact', () => {
   it('redacts authorization headers', () => {
     const headers = redactHeaders({
       Authorization: 'Bearer abc',
+      'set-cookie': 'session=abc',
       'X-Test': 'ok'
     });
 
     expect(headers?.Authorization).toBe('***');
+    expect(headers?.['set-cookie']).toBe('***');
     expect(headers?.['X-Test']).toBe('ok');
   });
 });


### PR DESCRIPTION
Closes #177

## Summary
- Add `filemaker.diagnostics.captureNetwork` and capture direct FileMaker Data API HTTP requests only when it is enabled.
- Store a redacted, in-memory 100-entry network log with request/response headers, bodies, status, duration, full URL, and relative URL.
- Add `FileMaker: Open Network Log` with a webview table, expandable request details, live refresh on new entries, and Clear.
- Extend redaction to cookie headers and token-like response payload values.

## Validation
- `ai-pipeline validate --id 177` — passed; no `validation.local` commands declared.
- `npm run lint -w extension` — passed.
- `npm run typecheck` — passed across all workspaces.
- `npm test` — passed: designer-ui 6 files/15 tests, runtime-next 3 files/9 tests, extension 79 files/450 tests.
- `npm run build -w shared` — passed; prerequisite for designer UI build resolution.
- `npm run build -w extension` — passed.

Evidence: `artifacts/local-review/issue-177-validation.md`.