### PR TITLE
Lazy-load FM client modules on first Connect (#173)

### DIFF
--- a/extension/src/commands/batch.ts
+++ b/extension/src/commands/batch.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 
 import type { RoleGuard } from '../enterprise/roleGuard';
-import type { BatchService} from '../services/batchService';
-import { inferExportFormat, parseBatchUpdateInput } from '../services/batchService';
+import type { BatchService } from '../services/batchService';
 import type { JobRunner } from '../services/jobRunner';
 import type { FMClient } from '../services/fmClient';
 import type { Logger } from '../services/logger';
@@ -96,6 +95,7 @@ export function registerBatchCommands(deps: RegisterBatchCommandsDeps): vscode.D
       const maxRecords = settingsService.getBatchMaxRecords();
 
       const performanceMode = roleGuard.resolvePerformanceMode();
+      const { inferExportFormat } = await import('../services/batchService');
       const selectedFormat = inferExportFormat(outputUri.fsPath);
       const format = performanceMode === 'high-scale' ? 'jsonl' : selectedFormat;
       const outputPath =
@@ -172,13 +172,14 @@ export function registerBatchCommands(deps: RegisterBatchCommandsDeps): vscode.D
           const sourceBytes = await vscode.workspace.fs.readFile(sourceUri);
           const sourceText = Buffer.from(sourceBytes).toString('utf8');
           const format = sourceUri.fsPath.toLowerCase().endsWith('.csv') ? 'csv' : 'json';
+          const { parseBatchUpdateInput } = await import('../services/batchService');
           const entries = parseBatchUpdateInput(sourceText, format);
           if (entries.length === 0) {
             vscode.window.showWarningMessage('No valid update rows found.');
             return;
           }
 
-          const defaults = batchService.getDefaultBatchUpdateOptions();
+          const defaults = await batchService.getDefaultBatchUpdateOptions();
           const dryRunSelection = await vscode.window.showQuickPick(
             [
               { label: 'Dry-run only (recommended)', value: true },

--- a/extension/src/commands/circuitBreaker.ts
+++ b/extension/src/commands/circuitBreaker.ts
@@ -1,10 +1,15 @@
 import * as vscode from 'vscode';
 
-import { renderCircuitBreakerStatus } from '../performance/circuitBreakerRegistry';
-import type { CircuitBreakerRegistry } from '../performance/circuitBreakerRegistry';
+import type { CircuitBreakerRegistry, RegistryEntry } from '../performance/circuitBreakerRegistry';
+
+type CircuitBreakerRegistryReader =
+  | Pick<CircuitBreakerRegistry, 'list'>
+  | {
+      list: () => RegistryEntry[] | Promise<RegistryEntry[]>;
+    };
 
 export interface CircuitBreakerCommandsDeps {
-  registry: CircuitBreakerRegistry;
+  registry: CircuitBreakerRegistryReader;
 }
 
 export function registerCircuitBreakerCommands(
@@ -13,7 +18,11 @@ export function registerCircuitBreakerCommands(
   const showStatus = vscode.commands.registerCommand(
     'filemakerDataApiTools.showCircuitBreakerStatus',
     async () => {
-      const content = renderCircuitBreakerStatus(deps.registry.list());
+      const [entries, { renderCircuitBreakerStatus }] = await Promise.all([
+        deps.registry.list(),
+        import('../performance/circuitBreakerRegistry')
+      ]);
+      const content = renderCircuitBreakerStatus(entries);
       const doc = await vscode.workspace.openTextDocument({
         language: 'markdown',
         content

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -23,7 +23,7 @@ import {
 import { ConnectionWizardPanel } from '../webviews/connectionWizard';
 import { QueryBuilderPanel } from '../webviews/queryBuilder';
 import { RecordViewerPanel } from '../webviews/recordViewer';
-import { retryWithBackoff, type BackoffPolicy } from '../utils/backoff';
+import type { BackoffPolicy } from '../utils/backoff';
 import { showConnectionQuickPick } from '../views/connectionStatusBar';
 
 interface RegisterCoreCommandDeps {
@@ -178,6 +178,7 @@ export function registerCoreCommands(deps: RegisterCoreCommandDeps): vscode.Disp
           statusBar.text = `$(sync~spin) FileMaker: Connecting to ${profile.name}…`;
           statusBar.show();
 
+          const { retryWithBackoff } = await import('../utils/backoff');
           await retryWithBackoff(
             () => fmClient.createSession(profile),
             policy,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -17,8 +17,8 @@ import { registerSchemaSnapshotCommands } from './commands/schemaSnapshots';
 import { registerScriptRunnerCommands } from './commands/scriptRunner';
 import { registerShowDiagnosticsCommand } from './commands/showDiagnostics';
 import { registerTypeGenCommands } from './commands/typeGen';
-import { BatchService } from './services/batchService';
-import { FMClient } from './services/fmClient';
+import type { BatchService } from './services/batchService';
+import type { FMClient } from './services/fmClient';
 import { HistoryStore } from './services/historyStore';
 import { JobRunner } from './services/jobRunner';
 import { Logger } from './services/logger';
@@ -37,11 +37,65 @@ import { EnvironmentCompareService } from './enterprise/environmentCompareServic
 import { RoleGuard } from './enterprise/roleGuard';
 import { MetricsStore } from './diagnostics/metricsStore';
 import { OfflineModeService } from './offline/offlineModeService';
-import { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
+import type { CircuitBreakerRegistry } from './performance/circuitBreakerRegistry';
 import { PluginRegistry } from './plugins/pluginRegistry';
 import { ConnectionStatusBar } from './views/connectionStatusBar';
 import { FMExplorerProvider } from './views/fmExplorer';
 import { OfflineStatusBar } from './views/offlineStatusBar';
+
+function createLazyFmClient(
+  loadClient: () => Promise<FMClient>,
+  getLoadedClient: () => FMClient | undefined
+): FMClient {
+  return new Proxy({} as FMClient, {
+    get(_target, property) {
+      if (property === 'then') {
+        return undefined;
+      }
+
+      if (property === 'invalidateProfileCache') {
+        return (profileId: string): void => {
+          getLoadedClient()?.invalidateProfileCache(profileId);
+        };
+      }
+
+      if (property === 'shouldRefreshSession') {
+        return (profileId: string, now?: number): boolean =>
+          getLoadedClient()?.shouldRefreshSession(profileId, now) ?? false;
+      }
+
+      return async (...args: unknown[]) => {
+        const client = await loadClient();
+        const value = (client as unknown as Record<PropertyKey, unknown>)[property];
+        return typeof value === 'function' ? value.apply(client, args) : value;
+      };
+    }
+  });
+}
+
+function createLazyBatchService(loadService: () => Promise<BatchService>): BatchService {
+  return new Proxy({} as BatchService, {
+    get(_target, property) {
+      if (property === 'then') {
+        return undefined;
+      }
+
+      return async (...args: unknown[]) => {
+        const service = await loadService();
+        const value = (service as unknown as Record<PropertyKey, unknown>)[property];
+        return typeof value === 'function' ? value.apply(service, args) : value;
+      };
+    }
+  });
+}
+
+function createLazyCircuitBreakerRegistry(
+  getLoadedRegistry: () => CircuitBreakerRegistry | undefined
+): Pick<CircuitBreakerRegistry, 'list'> {
+  return {
+    list: (...args) => getLoadedRegistry()?.list(...args) ?? []
+  };
+}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const settingsService = new SettingsService();
@@ -111,19 +165,97 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const timeoutMs = settingsService.getRequestTimeoutMs();
 
-  const fmClient = new FMClient(
-    secretStore,
-    logger,
-    timeoutMs,
-    undefined,
-    undefined,
-    historyStore,
-    metricsStore,
-    () => ({
-      maxAgeMs: settingsService.getSessionMaxAgeMs(),
-      refreshLeadMs: settingsService.getSessionRefreshLeadMs()
-    })
+  let loadedFmClient: FMClient | undefined;
+  let fmClientLoad: Promise<FMClient> | undefined;
+  const loadFmClient = (): Promise<FMClient> => {
+    if (loadedFmClient) {
+      return Promise.resolve(loadedFmClient);
+    }
+
+    fmClientLoad ??= import('./services/fmClient')
+      .then(({ FMClient }) => {
+        loadedFmClient = new FMClient(
+          secretStore,
+          logger,
+          timeoutMs,
+          undefined,
+          undefined,
+          historyStore,
+          metricsStore,
+          () => ({
+            maxAgeMs: settingsService.getSessionMaxAgeMs(),
+            refreshLeadMs: settingsService.getSessionRefreshLeadMs()
+          })
+        );
+        return loadedFmClient;
+      })
+      .catch((error) => {
+        fmClientLoad = undefined;
+        throw error;
+      });
+
+    return fmClientLoad;
+  };
+  const fmClient = createLazyFmClient(loadFmClient, () => loadedFmClient);
+
+  let loadedCircuitBreakerRegistry: CircuitBreakerRegistry | undefined;
+  let circuitBreakerRegistryLoad: Promise<CircuitBreakerRegistry> | undefined;
+  const loadCircuitBreakerRegistry = (): Promise<CircuitBreakerRegistry> => {
+    if (loadedCircuitBreakerRegistry) {
+      return Promise.resolve(loadedCircuitBreakerRegistry);
+    }
+
+    circuitBreakerRegistryLoad ??= import('./performance/circuitBreakerRegistry')
+      .then(({ CircuitBreakerRegistry }) => {
+        loadedCircuitBreakerRegistry = new CircuitBreakerRegistry();
+        return loadedCircuitBreakerRegistry;
+      })
+      .catch((error) => {
+        circuitBreakerRegistryLoad = undefined;
+        throw error;
+      });
+
+    return circuitBreakerRegistryLoad;
+  };
+  const circuitBreakerRegistry = createLazyCircuitBreakerRegistry(
+    () => loadedCircuitBreakerRegistry
   );
+
+  let loadedBatchService: BatchService | undefined;
+  let batchServiceLoad: Promise<BatchService> | undefined;
+  const loadBatchService = (): Promise<BatchService> => {
+    if (loadedBatchService) {
+      return Promise.resolve(loadedBatchService);
+    }
+
+    batchServiceLoad ??= Promise.all([
+      import('./services/batchService'),
+      loadCircuitBreakerRegistry()
+    ])
+      .then(([{ BatchService }, registry]) => {
+        loadedBatchService = new BatchService(fmClient, {
+          getMaxRecords: () => {
+            const configured = settingsService.getBatchMaxRecords();
+            return roleGuard.resolvePerformanceMode() === 'high-scale'
+              ? Math.min(configured, 10_000)
+              : configured;
+          },
+          getConcurrency: () => settingsService.getBatchConcurrency(),
+          getDryRunDefault: () => settingsService.getBatchDryRunDefault(),
+          getPerformanceMode: () => roleGuard.resolvePerformanceMode(),
+          circuitBreakerRegistry: registry
+        });
+        return loadedBatchService;
+      })
+      .catch((error) => {
+        batchServiceLoad = undefined;
+        throw error;
+      });
+
+    return batchServiceLoad;
+  };
+  const batchService = createLazyBatchService(loadBatchService);
+
   const schemaService = new SchemaService(fmClient, logger, {
     getCacheTtlMs: () =>
       normalizeSchemaCacheTtlMs(settingsService.getSchemaCacheTtlSeconds()),
@@ -141,19 +273,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     getOutputDir: () => settingsService.getTypegenOutputDir(),
     getWorkspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     isWorkspaceTrusted: () => vscode.workspace.isTrusted
-  });
-  const circuitBreakerRegistry = new CircuitBreakerRegistry();
-  const batchService = new BatchService(fmClient, {
-    getMaxRecords: () => {
-      const configured = settingsService.getBatchMaxRecords();
-      return roleGuard.resolvePerformanceMode() === 'high-scale'
-        ? Math.min(configured, 10_000)
-        : configured;
-    },
-    getConcurrency: () => settingsService.getBatchConcurrency(),
-    getDryRunDefault: () => settingsService.getBatchDryRunDefault(),
-    getPerformanceMode: () => roleGuard.resolvePerformanceMode(),
-    circuitBreakerRegistry
   });
   const pluginRegistry = new PluginRegistry(profileStore, fmClient, roleGuard, logger);
   const fmWebProjectService = new FmWebProjectService(

--- a/extension/test/unit/extensionLazyLoading.test.ts
+++ b/extension/test/unit/extensionLazyLoading.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+const lazyModules = vi.hoisted(() => ({
+  fmClientModuleLoaded: vi.fn(),
+  fmClientConstructed: vi.fn(),
+  createSession: vi.fn(async () => 'token'),
+  batchServiceModuleLoaded: vi.fn(),
+  circuitBreakerModuleLoaded: vi.fn(),
+  backoffModuleLoaded: vi.fn(),
+  retryWithBackoff: vi.fn(async (operation: () => Promise<unknown>) => operation())
+}));
+
+vi.mock('../../src/services/fmClient', () => {
+  lazyModules.fmClientModuleLoaded();
+
+  return {
+    FMClient: class {
+      public constructor(...args: unknown[]) {
+        lazyModules.fmClientConstructed(...args);
+      }
+
+      public createSession = lazyModules.createSession;
+      public deleteSession = async (): Promise<void> => {};
+      public listLayouts = async (): Promise<string[]> => [];
+      public listScripts = async (): Promise<string[]> => [];
+      public getRecord = async (): Promise<Record<string, unknown>> => ({});
+      public findRecords = async (): Promise<Record<string, unknown>> => ({});
+      public getLayoutMetadata = async (): Promise<Record<string, unknown>> => ({});
+      public editRecord = async (): Promise<Record<string, unknown>> => ({});
+      public createRecord = async (): Promise<Record<string, unknown>> => ({});
+      public deleteRecord = async (): Promise<Record<string, unknown>> => ({});
+      public runScript = async (): Promise<Record<string, unknown>> => ({});
+      public invalidateProfileCache(): void {}
+      public shouldRefreshSession(): boolean {
+        return false;
+      }
+    }
+  };
+});
+
+vi.mock('../../src/services/batchService', () => {
+  lazyModules.batchServiceModuleLoaded();
+
+  return {
+    BatchService: class {
+      public getDefaultBatchUpdateOptions(): { dryRun: boolean; concurrency: number } {
+        return { dryRun: true, concurrency: 4 };
+      }
+
+      public batchExportFind = async (): Promise<Record<string, unknown>> => ({});
+      public batchUpdate = async (): Promise<Record<string, unknown>> => ({});
+    },
+    inferExportFormat: vi.fn(() => 'jsonl'),
+    parseBatchUpdateInput: vi.fn(() => [])
+  };
+});
+
+vi.mock('../../src/performance/circuitBreakerRegistry', () => {
+  lazyModules.circuitBreakerModuleLoaded();
+
+  return {
+    CircuitBreakerRegistry: class {
+      public list(): unknown[] {
+        return [];
+      }
+
+      public register(): void {}
+      public recordTransition(): void {}
+      public unregister(): void {}
+    },
+    renderCircuitBreakerStatus: vi.fn(() => '# Circuit breakers')
+  };
+});
+
+vi.mock('../../src/utils/backoff', () => {
+  lazyModules.backoffModuleLoaded();
+
+  return {
+    retryWithBackoff: lazyModules.retryWithBackoff
+  };
+});
+
+describe('extension lazy FM runtime loading', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    installActivationVsCodeMocks();
+  });
+
+  it('does not load FM client, retry, batch, or circuit-breaker modules during activation', async () => {
+    const { activate } = await import('../../src/extension');
+    const context = createActivationContext();
+
+    await activate(context);
+    disposeSubscriptions(context);
+
+    expect(lazyModules.fmClientModuleLoaded).not.toHaveBeenCalled();
+    expect(lazyModules.backoffModuleLoaded).not.toHaveBeenCalled();
+    expect(lazyModules.batchServiceModuleLoaded).not.toHaveBeenCalled();
+    expect(lazyModules.circuitBreakerModuleLoaded).not.toHaveBeenCalled();
+  });
+
+  it('loads and caches the FM client module on the first Connect command', async () => {
+    const { activate } = await import('../../src/extension');
+    const context = createActivationContext();
+    await activate(context);
+
+    const connect = registeredCommand('filemakerDataApiTools.connect');
+    await connect({ profileId: 'p1' });
+    await connect({ profileId: 'p1' });
+    disposeSubscriptions(context);
+
+    expect(lazyModules.backoffModuleLoaded).toHaveBeenCalledTimes(1);
+    expect(lazyModules.fmClientModuleLoaded).toHaveBeenCalledTimes(1);
+    expect(lazyModules.fmClientConstructed).toHaveBeenCalledTimes(1);
+    expect(lazyModules.retryWithBackoff).toHaveBeenCalledTimes(2);
+    expect(lazyModules.createSession).toHaveBeenCalledTimes(2);
+    expect(lazyModules.batchServiceModuleLoaded).not.toHaveBeenCalled();
+    expect(lazyModules.circuitBreakerModuleLoaded).not.toHaveBeenCalled();
+  });
+});
+
+function installActivationVsCodeMocks(): void {
+  const disposable = () => ({ dispose: vi.fn() });
+  const createStatusBarItem = () => ({
+    text: '',
+    tooltip: undefined as string | undefined,
+    command: undefined as string | undefined,
+    backgroundColor: undefined as unknown,
+    show: vi.fn(),
+    hide: vi.fn(),
+    dispose: vi.fn()
+  });
+  const configuration = {
+    get: vi.fn((_key: string, defaultValue?: unknown) => defaultValue),
+    inspect: vi.fn(() => undefined),
+    update: vi.fn()
+  };
+
+  const vscodeMock = vscode as unknown as {
+    Disposable: new (callback: () => void) => vscode.Disposable;
+    StatusBarAlignment: { Left: number; Right: number };
+    ThemeColor: new (id: string) => unknown;
+    window: typeof vscode.window & {
+      createStatusBarItem: ReturnType<typeof vi.fn>;
+      registerTreeDataProvider: ReturnType<typeof vi.fn>;
+    };
+    workspace: typeof vscode.workspace & {
+      onDidGrantWorkspaceTrust: ReturnType<typeof vi.fn>;
+      onDidChangeConfiguration: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  vscodeMock.Disposable = class {
+    public constructor(private readonly callback: () => void) {}
+    public dispose(): void {
+      this.callback();
+    }
+  };
+  vscodeMock.StatusBarAlignment = { Left: 1, Right: 2 };
+  vscodeMock.ThemeColor = class {
+    public constructor(public readonly id: string) {}
+  };
+  vscodeMock.window.createStatusBarItem = vi.fn(createStatusBarItem);
+  vscodeMock.window.registerTreeDataProvider = vi.fn(disposable);
+  vscodeMock.workspace.onDidGrantWorkspaceTrust = vi.fn(disposable);
+  vscodeMock.workspace.onDidChangeConfiguration = vi.fn(disposable);
+  vi.mocked(vscode.workspace.getConfiguration).mockReturnValue(configuration as never);
+  vi.mocked(vscode.commands.registerCommand).mockImplementation(() => disposable());
+}
+
+function createActivationContext(): vscode.ExtensionContext {
+  const profile = {
+    id: 'p1',
+    name: 'Development',
+    serverUrl: 'https://fm.example.test',
+    database: 'Contacts',
+    authMode: 'direct',
+    username: 'admin'
+  };
+  const globalState = createMemento((key, defaultValue) => {
+    if (key === 'filemakerDataApiTools.profiles') {
+      return [profile];
+    }
+    return defaultValue;
+  });
+
+  return {
+    subscriptions: [],
+    extensionUri: vscode.Uri.file('/test/extension'),
+    globalState,
+    workspaceState: createMemento(),
+    secrets: {
+      get: vi.fn().mockResolvedValue(undefined),
+      store: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      onDidChange: vi.fn()
+    },
+    extension: {
+      id: 'deffenda.filemaker-data-api-tools',
+      packageJSON: { version: '1.1.0' }
+    },
+    extensionMode: 1,
+    asAbsolutePath: (path: string) => `/test/extension/${path}`
+  } as unknown as vscode.ExtensionContext;
+}
+
+function createMemento(
+  getValue: (key: string, defaultValue?: unknown) => unknown = (_key, defaultValue) => defaultValue
+): vscode.Memento {
+  return {
+    get: vi.fn(getValue),
+    update: vi.fn().mockResolvedValue(undefined),
+    keys: vi.fn(() => []),
+    setKeysForSync: vi.fn()
+  } as unknown as vscode.Memento;
+}
+
+function registeredCommand(commandId: string): (arg?: unknown) => Promise<void> {
+  const call = vi
+    .mocked(vscode.commands.registerCommand)
+    .mock.calls.find(([registeredId]) => registeredId === commandId);
+  expect(call).toBeDefined();
+  return call?.[1] as (arg?: unknown) => Promise<void>;
+}
+
+function disposeSubscriptions(context: vscode.ExtensionContext): void {
+  for (const subscription of context.subscriptions) {
+    subscription.dispose();
+  }
+}


### PR DESCRIPTION
Closes #173

## Summary
- Lazy-load the cached `FMClient` instance behind a dynamic import so activation no longer constructs the FileMaker client runtime.
- Defer retry, batch helper, and circuit-breaker registry imports until the commands that need them run.
- Add focused activation coverage proving FM client/retry/batch/circuit modules stay unloaded during activation and the first Connect reuses one cached client instance.

## Validation
- `GH_TOKEN="$(gh auth token)" ai-pipeline validate --id 173` -> passed; issue declares no `validation.local` commands.
- `npm run test -w extension -- extensionLazyLoading.test.ts activation.test.ts` -> 2 files, 4 tests passed.
- `npm run typecheck -w extension` -> passed.
- `npm run lint -w extension` -> passed.
- `npm run test -w extension` -> 79 files, 448 tests passed.
- `npm run typecheck --workspaces --if-present` -> passed.
- `npm run lint --workspaces --if-present` -> passed.
- `npm test --workspaces --if-present` -> designer-ui 6 files/15 tests, runtime-next 3 files/9 tests, extension 79 files/448 tests passed.
- `npm run build -w shared && npm run build -w extension && npm run package:check` -> passed; VSIX packaged successfully.