### PR TITLE
chore(eas): adopt v8.0.0 — self-hosted EAS bot workflows

### DIFF
--- a/.agent/rules.md
+++ b/.agent/rules.md
@@ -10,31 +10,36 @@ Source of truth:
 - Task state: external ticket board, not repo markdown
 - Runtime CLI: `ai-pipeline`
 - Shared skills: local agent skill roots linked from Enterprise AI Standards by BrewSync
+- Subagent roster: `ai/subagents.json` in the standards repo; adopted repos inherit it through EAS policy, not by copying it locally
 
 Startup:
 
-- If this branch contains a ticket id, run `ai-pipeline current`.
-- If this branch is `main`, `master`, or has no ticket id, run `ai-pipeline next` before starting implementation work.
-- If the user is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
-- Prefer shared skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- **Pick a role-scoped reading list** from `docs/eas-loading-guide.md` in the standards repo before reading `enterprise-ai-standards.md`. Loading the full standard wastes ~40K tokens for non-operator sessions; the guide names which §sections each role needs (planner / builder / reviewer / finisher / adopter / operator).
+- **Never full-read the heavy reference docs.** Do not read `enterprise-ai-standards.md`, `CHANGELOG.md`, or `docs/anti-patterns.md` end-to-end — look up the specific §section or A/C entry you need; full reads are operator-only. Per-role load budgets live in `docs/eas-loading-guide.md`.
+- If the branch contains a ticket id, run `ai-pipeline current`. If on `main` / `master` or no ticket id, run `ai-pipeline next` before implementing. If the operator is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
+- Read ticket comments with `ai-pipeline comments` (default: structured-metadata only; `--all` opts into full thread). Read diffs with `ai-pipeline diff` (lockfiles / generated / vendor stripped; 200KB cap). Never re-fetch raw thread or raw diff into the agent context.
+- Search before broad reads: use `rg`, targeted provider queries, or deterministic CLI commands to locate the exact symbol, config, or ticket evidence before opening large files/directories. Read only the surrounding lines needed, and stop exploration once the next safe implementation step is clear.
+- Prefer shared EAS skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- For read-heavy or synthesis-light work, delegate to subscription-backed cloud subagents per the §A13 roster (Codex subscription helpers preferred for GitHub-API work). Subagent prompts MUST carry role, read-only guardrails, scoped task, and expected output format. Synthesize multi-helper output with Lagrange before editing. Local helpers only when cloud runtime is unavailable, the work touches local-only files, secrets, or unpushed worktrees.
+- Treat `ai-pipeline claim` / `next` continuity notices as startup inputs: honor model-tier recommendations, repair skill-sync drift when reported, source MCP credentials through §D7 `cred.sh`.
 
 Hard rules:
 
-- Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists as AI task state.
-- Treat `ready_for_work` as unclaimed implementation work and `ready_for_local_testing` as unclaimed local-validation work; active leases are `in_development` and `in_local_testing`.
-- Cloud coding agents may transition complete work to `ready_for_local_testing`; local machines pick it up with `ai-pipeline validate-next`.
-- Cloud/container agents may run advisory `validation.cloud_preflight` checks with `ai-pipeline cloud-preflight`.
-- Do not open a PR or transition to `in_pr_review` until local validation has passed.
-- Keep production deploys in protected CI or trusted local runners; cloud coding containers may only do preview/sandbox deploys unless the repo explicitly documents a stricter trusted-cloud setup.
-- Do not create local lease, controller, planner, reviewer, or handoff state files.
-- Local validation must mirror CI-required flags as closely as practical; CI failures override local assumptions.
-- Validation scripts must tolerate unset optional CI environment variables under `set -u`.
-- Do not burn GitHub Actions minutes: run local validation before pushing, inspect failed check logs, and rerun CI only for a concrete infra, cancellation, or flaky-test reason.
-- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them; local AI reviews are advisory analysis unless explicitly required.
-- Track actionable local review findings in GitHub Issues, not markdown issue logs.
-- Do not commit shared skills into this repo; BrewSync owns machine-local skill linking and repair.
-- Keep `.ai/` local-only. This adapter file is tracked so fresh clones discover the EAS contract.
-- Repo-specific guidance may live outside the managed adapter block in this file; `ai-pipeline adopt --force` preserves text outside the block.
-- `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
+- AI task state lives on the external board only. Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists.
+- Canonical states: `ready_for_work` = unclaimed impl; `in_development` = active impl lease; `ready_for_local_testing` = cloud-completed handoff; `in_local_testing` = local-validation lease. Cloud agents may transition to `ready_for_local_testing`; local machines pick up with `ai-pipeline validate-next`.
+- Cloud/container agents run advisory `validation.cloud_preflight` checks only. Do not open a PR or transition to `in_pr_review` until local validation has passed. Production deploys stay on protected CI or trusted local runners; cloud containers may only do preview/sandbox deploys unless the repo explicitly documents trusted-cloud.
+- Local validation mirrors CI-required flags as closely as practical; CI failures override local assumptions. Validation scripts tolerate unset optional env vars under `set -u`. `ai-pipeline validate` base-freshness failures are blockers — rebase onto the named target and rerun before pushing.
+- Run local validation before pushing; inspect failed check logs; rerun CI only for concrete infra/cancellation/flaky-test reasons. Before `gh pr merge --auto`, use `tools/check-auto-merge-prereqs.sh` so branches without required status checks cannot merge vacuously.
+- Blocked PRs are first-class work. Before taking new `ready_for_work`, inspect owned open PRs in this repo; classify each red/dirty/blocked PR as `RED_CI_REQUIRED`, `SECURITY_REQUIRED`, `MERGE_CONFLICT_DIRTY`, `SIZE_REVIEW_BLOCK`, `REVIEW_THREAD_BLOCK`, `METADATA_GATE_BLOCK`, `WORKFLOW_SECONDARY_FAILURE`, or `DEPENDENCY_QUEUE`. Drain security/required CI first, then stale base, review/size blockers, metadata gates, workflow secondary failures, and clean dependency queues. Use `ai-pipeline review-comments --pr <number>` for review blockers. Do not stack more feature commits onto a `size:xl` / `needs-independent-review` branch; split/re-roll or get independent review.
+- Before editing any source file, search the issue tracker for the filename and the pattern you are about to add or change; pause and coordinate if an open issue is already refactoring that file or removing that pattern.
+- Enforce zero bad churn: keep edits scoped to the ticket/root cause, preserve the touched file's established style, avoid drive-by formatting/import sorting/public API renames, and do not commit scratch harnesses, IDE dotfiles, or agent-specific utility scripts unless the ticket explicitly requires them.
+- Treat push as remote verification, not iterative debugging: run the ticket's `validation.local` commands and cheap PR-essential/changelog validators before the first push whenever the repo provides them; if remote CI fails, inspect logs and reproduce locally before another push or rerun.
+- Budget-preflight notices from `ai-pipeline claim` / `next` are launch constraints: REDUCED → downshift + tighten tool scope; DEGRADED → finish only in-flight work at Mechanical tier; HALT → cadence stops unless explicitly overridden. Provider 429/503/overloaded responses follow §F7: record event, run `ai-pipeline rate-budget check`, downshift, bounded backoff, then escalate with terminal evidence.
+- Keep git identity aligned with §F6: `+<host>` email aliases for commits; `Co-Authored-By: <Agent> (<host>) ...` trailers for agents. Rerun `tools/ai-pipeline/scripts/install-host-identity.sh --host <host>` when adopt reports drift.
+- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them. Track actionable local-review findings in GitHub Issues, not markdown logs.
+- In-session subagents extend hands, not leases: they may search, read, inspect, summarize, classify, and report — they must NOT claim/transition tickets, add evidence, push, open/comment/merge PRs, or mutate provider state. Do not paste raw subagent transcripts into tickets, PRs, or commits; extract verified facts.
+- Before local validation, pre-push, or other expensive milestones, respect the board-state heartbeat; stop if the ticket is blocked, reassigned, or no longer in the active state for this session.
+- Do not commit shared skills (BrewSync owns machine-local linking) or local lease/controller/planner/handoff state files. `.ai/` is local-only. This adapter is tracked so fresh clones discover the EAS contract; repo-specific guidance lives outside the managed block (`ai-pipeline adopt --force` preserves it).
+- "Get latest" means update this repo only: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->

--- a/.github/workflows/eas-ai-approver.yml
+++ b/.github/workflows/eas-ai-approver.yml
@@ -20,7 +20,15 @@ env:
 
 jobs:
   route:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
+    # Skip rc files + clear $BASH_ENV so workflows don't depend on the
+    # runner user's shell init (failure mode documented in PR #214 /
+    # #334 of ABD-Enterprises/brew-sync).
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Route reviewer requests
         env:

--- a/.github/workflows/eas-auto-merge.yml
+++ b/.github/workflows/eas-auto-merge.yml
@@ -32,8 +32,15 @@ env:
 
 jobs:
   evaluate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     if: github.event.pull_request != null || github.event.check_suite != null
+    # Skip rc files + clear $BASH_ENV so workflows don't depend on the
+    # runner user's shell init (PR #214 / #334 in ABD-Enterprises/brew-sync).
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Validate inputs
         shell: bash

--- a/.github/workflows/eas-claude-code-agent.yml
+++ b/.github/workflows/eas-claude-code-agent.yml
@@ -77,8 +77,14 @@ jobs:
       vars.CLOUD_AGENT_ENABLED == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ai/ready-for-work'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     timeout-minutes: 60
+    env:
+      # Skip the runner user's shell init (PR #214 / #334 in brew-sync).
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
 
     steps:
       - name: Resolve issue number
@@ -100,10 +106,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PRS_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node (for repos that need it)
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
+      # actions/setup-node hardcodes /Users/runner/... for its tool
+      # cache and ignores RUNNER_TOOL_CACHE — fails on this self-hosted
+      # runner where the runner user is `deffenda`. Use the
+      # Homebrew-installed Node on the runner host instead.
+      - name: Verify Node from Homebrew
+        run: |
+          node --version
+          npm --version
 
       - name: Fetch issue details
         id: ticket

--- a/.github/workflows/eas-merge-override-note.yml
+++ b/.github/workflows/eas-merge-override-note.yml
@@ -36,8 +36,13 @@ permissions:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     if: github.event.pull_request != null && github.event.pull_request.merged == true
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Detect override and post note on linked issue
         env:

--- a/.github/workflows/eas-pr-size-label.yml
+++ b/.github/workflows/eas-pr-size-label.yml
@@ -31,8 +31,13 @@ permissions:
 
 jobs:
   size-label:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     if: github.event.pull_request != null
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Compute size and decide labels
         id: size

--- a/.github/workflows/eas-risk-label.yml
+++ b/.github/workflows/eas-risk-label.yml
@@ -16,8 +16,13 @@ env:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     if: github.event.pull_request != null
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -26,10 +31,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
+      # actions/setup-python hardcodes /Users/runner/... for its tool
+      # cache and ignores RUNNER_TOOL_CACHE — fails on this self-hosted
+      # runner. Use the Homebrew-installed python@3.13 directly with a
+      # per-run venv so quality-tool installs don't pollute the host.
+      - name: Set up per-run venv with Homebrew python@3.13
+        run: |
+          /opt/homebrew/opt/python@3.13/bin/python3.13 -m venv "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
 
       - name: Install PyYAML
         run: pip install --quiet "PyYAML==6.*"

--- a/.github/workflows/eas-superseded-check.yml
+++ b/.github/workflows/eas-superseded-check.yml
@@ -28,8 +28,13 @@ permissions:
 
 jobs:
   remind:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, local-build]
     if: github.event.pull_request != null && github.event.pull_request.merged == false
+    env:
+      BASH_ENV: ""
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
     steps:
       - name: Wait for closing comment
         # Operators frequently close-then-comment within a few seconds. A short

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,31 +10,36 @@ Source of truth:
 - Task state: external ticket board, not repo markdown
 - Runtime CLI: `ai-pipeline`
 - Shared skills: local agent skill roots linked from Enterprise AI Standards by BrewSync
+- Subagent roster: `ai/subagents.json` in the standards repo; adopted repos inherit it through EAS policy, not by copying it locally
 
 Startup:
 
-- If this branch contains a ticket id, run `ai-pipeline current`.
-- If this branch is `main`, `master`, or has no ticket id, run `ai-pipeline next` before starting implementation work.
-- If the user is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
-- Prefer shared skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- **Pick a role-scoped reading list** from `docs/eas-loading-guide.md` in the standards repo before reading `enterprise-ai-standards.md`. Loading the full standard wastes ~40K tokens for non-operator sessions; the guide names which §sections each role needs (planner / builder / reviewer / finisher / adopter / operator).
+- **Never full-read the heavy reference docs.** Do not read `enterprise-ai-standards.md`, `CHANGELOG.md`, or `docs/anti-patterns.md` end-to-end — look up the specific §section or A/C entry you need; full reads are operator-only. Per-role load budgets live in `docs/eas-loading-guide.md`.
+- If the branch contains a ticket id, run `ai-pipeline current`. If on `main` / `master` or no ticket id, run `ai-pipeline next` before implementing. If the operator is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
+- Read ticket comments with `ai-pipeline comments` (default: structured-metadata only; `--all` opts into full thread). Read diffs with `ai-pipeline diff` (lockfiles / generated / vendor stripped; 200KB cap). Never re-fetch raw thread or raw diff into the agent context.
+- Search before broad reads: use `rg`, targeted provider queries, or deterministic CLI commands to locate the exact symbol, config, or ticket evidence before opening large files/directories. Read only the surrounding lines needed, and stop exploration once the next safe implementation step is clear.
+- Prefer shared EAS skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- For read-heavy or synthesis-light work, delegate to subscription-backed cloud subagents per the §A13 roster (Codex subscription helpers preferred for GitHub-API work). Subagent prompts MUST carry role, read-only guardrails, scoped task, and expected output format. Synthesize multi-helper output with Lagrange before editing. Local helpers only when cloud runtime is unavailable, the work touches local-only files, secrets, or unpushed worktrees.
+- Treat `ai-pipeline claim` / `next` continuity notices as startup inputs: honor model-tier recommendations, repair skill-sync drift when reported, source MCP credentials through §D7 `cred.sh`.
 
 Hard rules:
 
-- Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists as AI task state.
-- Treat `ready_for_work` as unclaimed implementation work and `ready_for_local_testing` as unclaimed local-validation work; active leases are `in_development` and `in_local_testing`.
-- Cloud coding agents may transition complete work to `ready_for_local_testing`; local machines pick it up with `ai-pipeline validate-next`.
-- Cloud/container agents may run advisory `validation.cloud_preflight` checks with `ai-pipeline cloud-preflight`.
-- Do not open a PR or transition to `in_pr_review` until local validation has passed.
-- Keep production deploys in protected CI or trusted local runners; cloud coding containers may only do preview/sandbox deploys unless the repo explicitly documents a stricter trusted-cloud setup.
-- Do not create local lease, controller, planner, reviewer, or handoff state files.
-- Local validation must mirror CI-required flags as closely as practical; CI failures override local assumptions.
-- Validation scripts must tolerate unset optional CI environment variables under `set -u`.
-- Do not burn GitHub Actions minutes: run local validation before pushing, inspect failed check logs, and rerun CI only for a concrete infra, cancellation, or flaky-test reason.
-- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them; local AI reviews are advisory analysis unless explicitly required.
-- Track actionable local review findings in GitHub Issues, not markdown issue logs.
-- Do not commit shared skills into this repo; BrewSync owns machine-local skill linking and repair.
-- Keep `.ai/` local-only. This adapter file is tracked so fresh clones discover the EAS contract.
-- Repo-specific guidance may live outside the managed adapter block in this file; `ai-pipeline adopt --force` preserves text outside the block.
-- `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
+- AI task state lives on the external board only. Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists.
+- Canonical states: `ready_for_work` = unclaimed impl; `in_development` = active impl lease; `ready_for_local_testing` = cloud-completed handoff; `in_local_testing` = local-validation lease. Cloud agents may transition to `ready_for_local_testing`; local machines pick up with `ai-pipeline validate-next`.
+- Cloud/container agents run advisory `validation.cloud_preflight` checks only. Do not open a PR or transition to `in_pr_review` until local validation has passed. Production deploys stay on protected CI or trusted local runners; cloud containers may only do preview/sandbox deploys unless the repo explicitly documents trusted-cloud.
+- Local validation mirrors CI-required flags as closely as practical; CI failures override local assumptions. Validation scripts tolerate unset optional env vars under `set -u`. `ai-pipeline validate` base-freshness failures are blockers — rebase onto the named target and rerun before pushing.
+- Run local validation before pushing; inspect failed check logs; rerun CI only for concrete infra/cancellation/flaky-test reasons. Before `gh pr merge --auto`, use `tools/check-auto-merge-prereqs.sh` so branches without required status checks cannot merge vacuously.
+- Blocked PRs are first-class work. Before taking new `ready_for_work`, inspect owned open PRs in this repo; classify each red/dirty/blocked PR as `RED_CI_REQUIRED`, `SECURITY_REQUIRED`, `MERGE_CONFLICT_DIRTY`, `SIZE_REVIEW_BLOCK`, `REVIEW_THREAD_BLOCK`, `METADATA_GATE_BLOCK`, `WORKFLOW_SECONDARY_FAILURE`, or `DEPENDENCY_QUEUE`. Drain security/required CI first, then stale base, review/size blockers, metadata gates, workflow secondary failures, and clean dependency queues. Use `ai-pipeline review-comments --pr <number>` for review blockers. Do not stack more feature commits onto a `size:xl` / `needs-independent-review` branch; split/re-roll or get independent review.
+- Before editing any source file, search the issue tracker for the filename and the pattern you are about to add or change; pause and coordinate if an open issue is already refactoring that file or removing that pattern.
+- Enforce zero bad churn: keep edits scoped to the ticket/root cause, preserve the touched file's established style, avoid drive-by formatting/import sorting/public API renames, and do not commit scratch harnesses, IDE dotfiles, or agent-specific utility scripts unless the ticket explicitly requires them.
+- Treat push as remote verification, not iterative debugging: run the ticket's `validation.local` commands and cheap PR-essential/changelog validators before the first push whenever the repo provides them; if remote CI fails, inspect logs and reproduce locally before another push or rerun.
+- Budget-preflight notices from `ai-pipeline claim` / `next` are launch constraints: REDUCED → downshift + tighten tool scope; DEGRADED → finish only in-flight work at Mechanical tier; HALT → cadence stops unless explicitly overridden. Provider 429/503/overloaded responses follow §F7: record event, run `ai-pipeline rate-budget check`, downshift, bounded backoff, then escalate with terminal evidence.
+- Keep git identity aligned with §F6: `+<host>` email aliases for commits; `Co-Authored-By: <Agent> (<host>) ...` trailers for agents. Rerun `tools/ai-pipeline/scripts/install-host-identity.sh --host <host>` when adopt reports drift.
+- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them. Track actionable local-review findings in GitHub Issues, not markdown logs.
+- In-session subagents extend hands, not leases: they may search, read, inspect, summarize, classify, and report — they must NOT claim/transition tickets, add evidence, push, open/comment/merge PRs, or mutate provider state. Do not paste raw subagent transcripts into tickets, PRs, or commits; extract verified facts.
+- Before local validation, pre-push, or other expensive milestones, respect the board-state heartbeat; stop if the ticket is blocked, reassigned, or no longer in the active state for this session.
+- Do not commit shared skills (BrewSync owns machine-local linking) or local lease/controller/planner/handoff state files. `.ai/` is local-only. This adapter is tracked so fresh clones discover the EAS contract; repo-specific guidance lives outside the managed block (`ai-pipeline adopt --force` preserves it).
+- "Get latest" means update this repo only: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,31 +10,36 @@ Source of truth:
 - Task state: external ticket board, not repo markdown
 - Runtime CLI: `ai-pipeline`
 - Shared skills: local agent skill roots linked from Enterprise AI Standards by BrewSync
+- Subagent roster: `ai/subagents.json` in the standards repo; adopted repos inherit it through EAS policy, not by copying it locally
 
 Startup:
 
-- If this branch contains a ticket id, run `ai-pipeline current`.
-- If this branch is `main`, `master`, or has no ticket id, run `ai-pipeline next` before starting implementation work.
-- If the user is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
-- Prefer shared skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- **Pick a role-scoped reading list** from `docs/eas-loading-guide.md` in the standards repo before reading `enterprise-ai-standards.md`. Loading the full standard wastes ~40K tokens for non-operator sessions; the guide names which §sections each role needs (planner / builder / reviewer / finisher / adopter / operator).
+- **Never full-read the heavy reference docs.** Do not read `enterprise-ai-standards.md`, `CHANGELOG.md`, or `docs/anti-patterns.md` end-to-end — look up the specific §section or A/C entry you need; full reads are operator-only. Per-role load budgets live in `docs/eas-loading-guide.md`.
+- If the branch contains a ticket id, run `ai-pipeline current`. If on `main` / `master` or no ticket id, run `ai-pipeline next` before implementing. If the operator is asking for new work and no ticket exists, run `ai-pipeline plan "<title>"`.
+- Read ticket comments with `ai-pipeline comments` (default: structured-metadata only; `--all` opts into full thread). Read diffs with `ai-pipeline diff` (lockfiles / generated / vendor stripped; 200KB cap). Never re-fetch raw thread or raw diff into the agent context.
+- Search before broad reads: use `rg`, targeted provider queries, or deterministic CLI commands to locate the exact symbol, config, or ticket evidence before opening large files/directories. Read only the surrounding lines needed, and stop exploration once the next safe implementation step is clear.
+- Prefer shared EAS skills for repo intake, git hygiene, validation, PR response, token conservation, churn avoidance, and multi-Mac workflow.
+- For read-heavy or synthesis-light work, delegate to subscription-backed cloud subagents per the §A13 roster (Codex subscription helpers preferred for GitHub-API work). Subagent prompts MUST carry role, read-only guardrails, scoped task, and expected output format. Synthesize multi-helper output with Lagrange before editing. Local helpers only when cloud runtime is unavailable, the work touches local-only files, secrets, or unpushed worktrees.
+- Treat `ai-pipeline claim` / `next` continuity notices as startup inputs: honor model-tier recommendations, repair skill-sync drift when reported, source MCP credentials through §D7 `cred.sh`.
 
 Hard rules:
 
-- Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists as AI task state.
-- Treat `ready_for_work` as unclaimed implementation work and `ready_for_local_testing` as unclaimed local-validation work; active leases are `in_development` and `in_local_testing`.
-- Cloud coding agents may transition complete work to `ready_for_local_testing`; local machines pick it up with `ai-pipeline validate-next`.
-- Cloud/container agents may run advisory `validation.cloud_preflight` checks with `ai-pipeline cloud-preflight`.
-- Do not open a PR or transition to `in_pr_review` until local validation has passed.
-- Keep production deploys in protected CI or trusted local runners; cloud coding containers may only do preview/sandbox deploys unless the repo explicitly documents a stricter trusted-cloud setup.
-- Do not create local lease, controller, planner, reviewer, or handoff state files.
-- Local validation must mirror CI-required flags as closely as practical; CI failures override local assumptions.
-- Validation scripts must tolerate unset optional CI environment variables under `set -u`.
-- Do not burn GitHub Actions minutes: run local validation before pushing, inspect failed check logs, and rerun CI only for a concrete infra, cancellation, or flaky-test reason.
-- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them; local AI reviews are advisory analysis unless explicitly required.
-- Track actionable local review findings in GitHub Issues, not markdown issue logs.
-- Do not commit shared skills into this repo; BrewSync owns machine-local skill linking and repair.
-- Keep `.ai/` local-only. This adapter file is tracked so fresh clones discover the EAS contract.
-- Repo-specific guidance may live outside the managed adapter block in this file; `ai-pipeline adopt --force` preserves text outside the block.
-- `get latest` means update only this repo: `git fetch origin --prune && git pull --ff-only`.
+- AI task state lives on the external board only. Do not use `docs/roadmap`, `state/`, `work.json`, `state.json`, `markdown.json`, or markdown task lists.
+- Canonical states: `ready_for_work` = unclaimed impl; `in_development` = active impl lease; `ready_for_local_testing` = cloud-completed handoff; `in_local_testing` = local-validation lease. Cloud agents may transition to `ready_for_local_testing`; local machines pick up with `ai-pipeline validate-next`.
+- Cloud/container agents run advisory `validation.cloud_preflight` checks only. Do not open a PR or transition to `in_pr_review` until local validation has passed. Production deploys stay on protected CI or trusted local runners; cloud containers may only do preview/sandbox deploys unless the repo explicitly documents trusted-cloud.
+- Local validation mirrors CI-required flags as closely as practical; CI failures override local assumptions. Validation scripts tolerate unset optional env vars under `set -u`. `ai-pipeline validate` base-freshness failures are blockers — rebase onto the named target and rerun before pushing.
+- Run local validation before pushing; inspect failed check logs; rerun CI only for concrete infra/cancellation/flaky-test reasons. Before `gh pr merge --auto`, use `tools/check-auto-merge-prereqs.sh` so branches without required status checks cannot merge vacuously.
+- Blocked PRs are first-class work. Before taking new `ready_for_work`, inspect owned open PRs in this repo; classify each red/dirty/blocked PR as `RED_CI_REQUIRED`, `SECURITY_REQUIRED`, `MERGE_CONFLICT_DIRTY`, `SIZE_REVIEW_BLOCK`, `REVIEW_THREAD_BLOCK`, `METADATA_GATE_BLOCK`, `WORKFLOW_SECONDARY_FAILURE`, or `DEPENDENCY_QUEUE`. Drain security/required CI first, then stale base, review/size blockers, metadata gates, workflow secondary failures, and clean dependency queues. Use `ai-pipeline review-comments --pr <number>` for review blockers. Do not stack more feature commits onto a `size:xl` / `needs-independent-review` branch; split/re-roll or get independent review.
+- Before editing any source file, search the issue tracker for the filename and the pattern you are about to add or change; pause and coordinate if an open issue is already refactoring that file or removing that pattern.
+- Enforce zero bad churn: keep edits scoped to the ticket/root cause, preserve the touched file's established style, avoid drive-by formatting/import sorting/public API renames, and do not commit scratch harnesses, IDE dotfiles, or agent-specific utility scripts unless the ticket explicitly requires them.
+- Treat push as remote verification, not iterative debugging: run the ticket's `validation.local` commands and cheap PR-essential/changelog validators before the first push whenever the repo provides them; if remote CI fails, inspect logs and reproduce locally before another push or rerun.
+- Budget-preflight notices from `ai-pipeline claim` / `next` are launch constraints: REDUCED → downshift + tighten tool scope; DEGRADED → finish only in-flight work at Mechanical tier; HALT → cadence stops unless explicitly overridden. Provider 429/503/overloaded responses follow §F7: record event, run `ai-pipeline rate-budget check`, downshift, bounded backoff, then escalate with terminal evidence.
+- Keep git identity aligned with §F6: `+<host>` email aliases for commits; `Co-Authored-By: <Agent> (<host>) ...` trailers for agents. Rerun `tools/ai-pipeline/scripts/install-host-identity.sh --host <host>` when adopt reports drift.
+- Run configured local-first reviews before CI spend when `.ai/config.json#local_review` declares them. Track actionable local-review findings in GitHub Issues, not markdown logs.
+- In-session subagents extend hands, not leases: they may search, read, inspect, summarize, classify, and report — they must NOT claim/transition tickets, add evidence, push, open/comment/merge PRs, or mutate provider state. Do not paste raw subagent transcripts into tickets, PRs, or commits; extract verified facts.
+- Before local validation, pre-push, or other expensive milestones, respect the board-state heartbeat; stop if the ticket is blocked, reassigned, or no longer in the active state for this session.
+- Do not commit shared skills (BrewSync owns machine-local linking) or local lease/controller/planner/handoff state files. `.ai/` is local-only. This adapter is tracked so fresh clones discover the EAS contract; repo-specific guidance lives outside the managed block (`ai-pipeline adopt --force` preserves it).
+- "Get latest" means update this repo only: `git fetch origin --prune && git pull --ff-only`.
 
 <!-- END ENTERPRISE-AI-STANDARDS LOCAL ADAPTER -->

--- a/internal/operator-notes/README.md
+++ b/internal/operator-notes/README.md
@@ -1,0 +1,20 @@
+# Operator Notes
+
+This directory stores operator-curated context for Planner runs.
+
+Use one Markdown file per topic. Good notes explain durable operating context:
+why this repo does something, patterns agents should preserve, and practices
+agents should avoid.
+
+Rules:
+
+- Keep notes as prose written or approved by the operator.
+- Do not store secrets, credentials, tokens, or machine-local paths here.
+- Planner runs read these notes before refining tickets.
+- Planner output cites the note that influenced each non-obvious decision.
+
+Suggested files:
+
+- onboarding.md
+- release-process.md
+- recurring-failure-modes.md


### PR DESCRIPTION
Adopts ABD-Enterprises/enterprise-ai-standards@v8.0.0 to route the
EAS bot workflows onto the org-level self-hosted macOS runner instead
of GHA-hosted ubuntu-latest. Fixes the budget-exhaustion failure mode
where `evaluate`/`route`/`label`/`size-label` were failing instantly
across every PR with *"The job was not started because recent account
payments have failed."*

Migration was generated by:

```
ai-pipeline adopt --provider github --project ABD-Enterprises --force --with-workflows
```

This commit ALSO refreshes the §D4 BREAKING managed adapters
(`AGENTS.md`, `CLAUDE.md`, `.agent/rules.md`) to the v8.0.0 schema.
Content outside the managed block is preserved byte-for-byte.

See [enterprise-ai-standards v8.0.0 release notes](https://github.com/ABD-Enterprises/enterprise-ai-standards/releases/tag/v8.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)