### PR TITLE
feat(extension): offer "Connect Now" after saving a connection profile

### DIFF
--- a/designer-ui/src/css.d.ts
+++ b/designer-ui/src/css.d.ts
@@ -1,0 +1,4 @@
+// Ambient declaration so TypeScript accepts side-effect CSS imports
+// (`import './styles.css'`). esbuild handles the actual bundling at build
+// time; this is type-only and emits nothing.
+declare module '*.css';

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [FEATURE] Connection wizard now offers a **Connect Now** action immediately after a profile is saved, so first-run users flow straight from "saved" to an open session without hunting for **FileMaker: Connect** in the Command Palette. Editing an existing profile offers **Reconnect now** instead.
+
 - [FEATURE] Added a Layout Inspector view that shows selected layout fields, portals, value lists, and field validation rules with refreshable session caching.
 
 - Attributed the extension to ABD Enterprises in README and `package.json`:

--- a/extension/docs/QA/SMOKE_TEST_v1_1_0.md
+++ b/extension/docs/QA/SMOKE_TEST_v1_1_0.md
@@ -263,15 +263,17 @@ Skip this scenario if SC-01 passed. Use it if Marketplace install is unavailable
 
 **Steps:**
 1. Click **Save Profile** in the wizard.
-2. Observe the bottom status bar of VS Code.
-3. Run `⌘+Shift+P` → **FileMaker: Connect**. Pick your profile from the list.
+2. Observe the inline status under the form and the toast that appears.
+3. In the `Profile "<name>" saved. Connect now to start a session?` toast, click **Connect Now**.
+4. Observe the bottom status bar of VS Code.
 
 **Expected:**
-- Save: a success toast appears: `Profile "<name>" saved. Use FileMaker: Connect to start a session.`
-- After **Connect**: the bottom status bar shows a persistent indicator like `$(plug) FileMaker: <profile name>`.
+- Save: the inline form status reads `Profile "<name>" saved.` and a toast appears: `Profile "<name>" saved. Connect now to start a session?` with a **Connect Now** action.
+- Clicking **Connect Now** opens a session directly (no need to find **FileMaker: Connect** in the palette). **FileMaker: Connect** from the Command Palette remains available as an alternative.
+- After connecting: the bottom status bar shows a persistent indicator like `$(plug) FileMaker: <profile name>`.
 - The status bar item is **always visible** (not just briefly shown then dismissed).
 
-**Pass criteria:** Save succeeded, persistent status bar item appears and stays.
+**Pass criteria:** Save succeeded, the **Connect Now** action opened a session, persistent status bar item appears and stays.
 
 **On failure:** Capture: status bar screenshot, Output panel.
 

--- a/extension/docs/walkthroughs/test-connect.md
+++ b/extension/docs/walkthroughs/test-connect.md
@@ -2,10 +2,11 @@
 
 ![Schema and batch tooling visible after connecting](../marketplace/schema-and-batch.png)
 
-Once you've saved a profile, **click Connect**: either the **Connect**
-button in the welcome view, run **FileMaker: Connect** from the Command
-Palette (`Ctrl/Cmd+Shift+P`), or right-click the profile in the FileMaker
-sidebar and choose **Connect**.
+Right after you save a profile, the wizard offers a **Connect Now** action —
+click it to open a session immediately. You can also connect later: use the
+**Connect** button in the welcome view, run **FileMaker: Connect** from the
+Command Palette (`Ctrl/Cmd+Shift+P`), or right-click the profile in the
+FileMaker sidebar and choose **Connect**.
 
 What you'll see:
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -983,7 +983,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.1",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "~1.96.0",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.33.1",
     "@vitest/coverage-v8": "^4.1.7",

--- a/extension/src/webviews/connectionWizard/index.ts
+++ b/extension/src/webviews/connectionWizard/index.ts
@@ -203,17 +203,53 @@ export class ConnectionWizardPanel {
         await this.secretStore.deletePassword(profile.id);
       }
 
+      const isNewProfile = !this.editingProfile;
       this.editingProfile = profile;
 
       await this.panel.webview.postMessage({
         type: 'saveSuccess',
-        message: `Profile "${profile.name}" saved. Use FileMaker: Connect to start a session.`
+        message: `Profile "${profile.name}" saved.`
       });
+
+      // Close the gap between "saved" and "connected": the natural next step
+      // after creating a profile is to open a session, but until now the user
+      // had to discover and run FileMaker: Connect themselves. Offer it inline
+      // as a native toast action so first-run onboarding flows straight through.
+      void this.offerConnect(profile, isNewProfile);
     } catch (error) {
       await this.panel.webview.postMessage({
         type: 'saveError',
         message: toUserErrorMessage(error, 'Failed to save profile.')
       });
+    }
+  }
+
+  /**
+   * Surface a "Connect Now" toast after a save so the user can open a session
+   * without hunting for the command. The connect command resolves the profile
+   * from the `{ profileId }` arg, so we hand it the freshly-saved id directly.
+   * Failures here are non-fatal — the profile is already persisted and the user
+   * can connect later from the sidebar or Command Palette.
+   */
+  private async offerConnect(
+    profile: ConnectionProfile,
+    isNewProfile: boolean
+  ): Promise<void> {
+    try {
+      const prompt = isNewProfile
+        ? `Profile "${profile.name}" saved. Connect now to start a session?`
+        : `Profile "${profile.name}" updated. Reconnect now?`;
+      const choice = await vscode.window.showInformationMessage(
+        prompt,
+        'Connect Now'
+      );
+      if (choice === 'Connect Now') {
+        await vscode.commands.executeCommand('filemakerDataApiTools.connect', {
+          profileId: profile.id
+        });
+      }
+    } catch (error) {
+      this.logger.warn('Failed to offer post-save connect.', { error });
     }
   }
 

--- a/extension/test/unit/typeGenService.test.ts
+++ b/extension/test/unit/typeGenService.test.ts
@@ -146,6 +146,11 @@ void run;
       target: ts.ScriptTarget.ES2020,
       module: ts.ModuleKind.CommonJS,
       moduleResolution: ts.ModuleResolutionKind.Node10,
+      // TypeScript 6.0 deprecates the node10 resolver; this inline program
+      // still targets it deliberately (it mirrors a consumer's classic
+      // CommonJS tsconfig). Silence the deprecation so the diagnostics
+      // assertion below stays focused on the generated code, not tooling.
+      ignoreDeprecations: '6.0',
       lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
       skipLibCheck: true
     });

--- a/extension/test/unit/webviews/connectionWizardConnectOffer.test.ts
+++ b/extension/test/unit/webviews/connectionWizardConnectOffer.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+import { ConnectionWizardPanel } from '../../../src/webviews/connectionWizard';
+
+/**
+ * Behavioral guard for the post-save onboarding flow: after a profile is saved
+ * the wizard must offer a native "Connect Now" toast and, when the user accepts,
+ * dispatch FileMaker: Connect with the freshly-saved profile id. This is the
+ * step that closes the gap between "saved" and "connected" for first-run users.
+ */
+
+interface CapturedPanel {
+  fireMessage: (message: unknown) => Promise<void>;
+  posted: unknown[];
+}
+
+function setupPanel(): CapturedPanel {
+  const posted: unknown[] = [];
+  let messageHandler: ((message: unknown) => unknown) | undefined;
+
+  const panel = {
+    webview: {
+      html: '',
+      cspSource: 'vscode-resource:',
+      asWebviewUri: (uri: unknown) => uri,
+      postMessage: vi.fn((message: unknown) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      }),
+      onDidReceiveMessage: (handler: (message: unknown) => unknown) => {
+        messageHandler = handler;
+        return { dispose: vi.fn() };
+      }
+    },
+    onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+    reveal: vi.fn(),
+    dispose: vi.fn()
+  };
+
+  // The panel tracks a single live instance in a static field; reset it so each
+  // test gets a fresh panel (and a freshly registered message handler) instead
+  // of the reuse/reveal branch in createOrShow.
+  (ConnectionWizardPanel as unknown as { currentPanel: unknown }).currentPanel =
+    undefined;
+
+  vi.mocked(vscode.window.createWebviewPanel).mockReturnValue(
+    panel as unknown as vscode.WebviewPanel
+  );
+
+  const context = {
+    extensionUri: { fsPath: '/ext' },
+    extension: { id: 'abd.fm' }
+  } as unknown as vscode.ExtensionContext;
+
+  const profileStore = {
+    upsertProfile: vi.fn(async () => undefined)
+  };
+  const secretStore = {
+    setPassword: vi.fn(async () => undefined),
+    deleteProxyApiKey: vi.fn(async () => undefined),
+    deletePassword: vi.fn(async () => undefined),
+    setProxyApiKey: vi.fn(async () => undefined)
+  };
+  const fmClient = {};
+  const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+  ConnectionWizardPanel.createOrShow(
+    context,
+    profileStore as never,
+    secretStore as never,
+    fmClient as never,
+    logger as never
+  );
+
+  return {
+    fireMessage: async (message: unknown) => {
+      await messageHandler?.(message);
+    },
+    posted
+  };
+}
+
+const validSavePayload = {
+  type: 'save',
+  payload: {
+    name: 'Production',
+    authMode: 'direct',
+    serverUrl: 'https://fm.example.com',
+    database: 'MyDatabase',
+    apiBasePath: '/fmi/data',
+    apiVersionPath: 'vLatest',
+    username: 'api_user',
+    password: 'secret'
+  }
+};
+
+describe('Connection wizard post-save connect offer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers Connect Now after a successful save', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as never);
+
+    const panel = setupPanel();
+    await panel.fireMessage(validSavePayload);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    const [prompt, action] = vi.mocked(vscode.window.showInformationMessage).mock.calls[0];
+    expect(prompt).toContain('Connect now');
+    expect(action).toBe('Connect Now');
+  });
+
+  it('dispatches FileMaker: Connect with the saved profile id when accepted', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(
+      'Connect Now' as never
+    );
+
+    const panel = setupPanel();
+    await panel.fireMessage(validSavePayload);
+    // Let the fire-and-forget offerConnect promise settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'filemakerDataApiTools.connect',
+      expect.objectContaining({ profileId: expect.any(String) })
+    );
+  });
+
+  it('does not connect when the user dismisses the toast', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValue(undefined as never);
+
+    const panel = setupPanel();
+    await panel.fireMessage(validSavePayload);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+      'filemakerDataApiTools.connect',
+      expect.anything()
+    );
+  });
+});

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "sourceMap": true,
     "types": ["node", "vscode"]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.9.1",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "~1.96.0",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.33.1",
         "@vitest/coverage-v8": "^4.1.7",
@@ -63,6 +63,13 @@
       "engines": {
         "vscode": "^1.96.0"
       }
+    },
+    "extension/node_modules/@types/vscode": {
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
+      "dev": true,
+      "license": "MIT"
     },
     "extension/node_modules/@vitest/coverage-v8": {
       "version": "4.1.7",
@@ -2810,13 +2817,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/vscode": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
-      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "designer-ui",
         "runtime-next",
         "extension"
-      ]
+      ],
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.7"
+      }
     },
     "designer-ui": {
       "name": "@fmweb/designer-ui",
@@ -70,37 +73,6 @@
       "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
       "dev": true,
       "license": "MIT"
-    },
-    "extension/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.7",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.7",
-        "vitest": "4.1.7"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -583,6 +555,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -605,6 +578,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -622,6 +596,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -639,6 +614,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -656,6 +632,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -673,6 +650,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -690,6 +668,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -707,6 +686,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -724,6 +704,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -741,6 +722,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -758,6 +740,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -775,6 +758,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -792,6 +776,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -809,6 +794,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -826,6 +812,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -843,6 +830,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -860,6 +848,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -877,6 +866,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -894,6 +884,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -911,6 +902,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -928,6 +920,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -945,6 +938,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -962,6 +956,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -979,6 +974,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -996,6 +992,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1013,6 +1010,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1030,6 +1028,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1047,6 +1046,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1805,6 +1805,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
@@ -2037,6 +2038,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2054,6 +2056,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2071,6 +2074,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2088,6 +2092,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2105,6 +2110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2122,6 +2128,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2139,6 +2146,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2156,6 +2164,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2173,6 +2182,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2190,6 +2200,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2207,6 +2218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2224,6 +2236,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2238,6 +2251,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -2260,6 +2274,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2277,6 +2292,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2708,6 +2724,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3066,6 +3083,37 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -5032,6 +5080,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -5949,6 +5998,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5970,6 +6020,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5991,6 +6042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6012,6 +6064,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6033,6 +6086,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6054,6 +6108,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6075,6 +6130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6096,6 +6152,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6117,6 +6174,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6138,6 +6196,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6159,6 +6218,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "package:vsix": "npm run build --workspaces --if-present && npm run package:vsix -w extension",
     "setup": "node ./setup.mjs"
   },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.7"
+  },
   "overrides": {
     "postcss": "^8.5.10"
   }


### PR DESCRIPTION
## What

Improves the first-run onboarding flow. After a profile is saved in the connection wizard, the extension now surfaces a native **Connect Now** toast and dispatches **FileMaker: Connect** with the freshly-saved profile when the user accepts. Editing an existing profile offers **Reconnect now** instead.

## Why

Previously the wizard ended at *"Profile saved. Use FileMaker: Connect to start a session."* — leaving the user to discover and run the connect command themselves. That handoff was the single biggest gap in the onboarding path between creating a profile and seeing data. The wizard already knew the profile id; this just wires the obvious next step.

## How

- `ConnectionWizardPanel.handleSave` calls a new `offerConnect(profile, isNewProfile)` after a successful save.
- The offer is fire-and-forget and non-fatal: the profile is already persisted, so a dismissed toast or a failed connect leaves the user able to connect later from the sidebar or Command Palette. Errors are logged via the existing logger.
- The connect command resolves its profile from a `{ profileId }` arg, so the saved id is handed in directly — no new plumbing.

## Docs & tests

- Updated the Getting Started walkthrough (`test-connect.md`) and the v1.1.0 QA smoke test (`SC-09`) to describe the new flow.
- Added `connectionWizardConnectOffer.test.ts` covering three paths: the offer is shown after save, accepting dispatches connect with the profile id, and dismissing does nothing.
- Added a CHANGELOG entry under **Unreleased**.

## CI unblock (2nd commit)

The first CI run surfaced **three pre-existing failures inherited from dependabot bump #245** (the commit this branch was based on, which raised TypeScript to `^6.0.3` and `@types/vscode` to `^1.120.0` without the accompanying updates) — none caused by the onboarding change. Fixed in a separate, clearly-scoped commit:

- **typecheck (extension):** TS 6.0 deprecates `moduleResolution: "node"` (node10). Added `"ignoreDeprecations": "6.0"` to `extension/tsconfig.json` (TS's own recommended remedy) and to the inline node10 program in `typeGenService.test.ts`.
- **typecheck (designer-ui):** TS 6.0 rejects `import './styles.css'` with no ambient declaration. Added `designer-ui/src/css.d.ts` (`declare module '*.css'`) — type-only; esbuild handles bundling.
- **package:check:** `vsce` refused because `@types/vscode ^1.120.0` exceeds `engines.vscode ^1.96.0`. Pinned `@types/vscode` to `~1.96.0` so the types track the minimum supported VS Code; typecheck still passes, confirming no post-1.96 APIs are in use.

## Validation

All CI steps pass locally: `lint`, `typecheck`, `test:coverage` (**467 passed**), `build`, `package:check` (VSIX 2.36 MB, under the 5 MiB budget), and `npm audit --omit=dev --audit-level=high`.

https://claude.ai/code/session_01FDrP6DntTQJogi7UvdmbYq