### PR TITLE
release: v1.2.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0
+
+_Released 2026-05-31._
+
 - [FEATURE] Connection wizard now offers a **Connect Now** action immediately after a profile is saved, so first-run users flow straight from "saved" to an open session without hunting for **FileMaker: Connect** in the Command Palette. Editing an existing profile offers **Reconnect now** instead.
 
 - [FEATURE] Added a Layout Inspector view that shows selected layout fields, portals, value lists, and field validation rules with refreshable session caching.

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "filemaker-data-api-tools",
   "displayName": "FileMaker Data API Tools",
   "description": "Query, edit, and explore FileMaker data without leaving VS Code. Full CRUD for fmrest, visual query builder, schema diffing, batch import/export, and TypeScript type generation for Claris FileMaker Server and FileMaker Cloud.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "deffenda",
   "license": "MIT",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
     },
     "extension": {
       "name": "filemaker-data-api-tools",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0",


### PR DESCRIPTION
## Release v1.2.0

Version bump + finalized CHANGELOG. Once this merges, pushing the `v1.2.0` tag triggers the CI `package`/`publish` jobs → Marketplace (`vsce publish`) + GitHub Release (notes from the CHANGELOG `## 1.2.0` section).

### Changes
- `extension/package.json`: `1.1.0` → `1.2.0`
- `extension/CHANGELOG.md`: `Unreleased` → `## 1.2.0` (dated), new empty `Unreleased` placeholder
- `package-lock.json`: synced extension workspace version

### Release contents (1.2.0)
- **Connect Now** action after saving a connection profile (and Reconnect now when editing)
- **Layout Inspector** view (fields, portals, value lists, validation rules)
- ABD Enterprises attribution in README/`package.json`

### Validation
- `npm run build` + `npm run package:check` → `filemaker-data-api-tools-1.2.0.vsix` (174 files, 2.36 MB, under the 5 MiB budget) ✅
- `tools/release-notes.sh v1.2.0` extracts the correct CHANGELOG section ✅
- Underlying code is unchanged from the already-green `main` (this PR only touches version metadata + changelog)

### Publish steps after merge
1. Tag the merge commit `v1.2.0` and push the tag.
2. CI `publish` job runs `vsce publish` (uses the `VSCE_PAT` secret) and creates the GitHub Release.

https://claude.ai/code/session_01FDrP6DntTQJogi7UvdmbYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDrP6DntTQJogi7UvdmbYq)_